### PR TITLE
Move the storage of plural rules to PO files and simplify config

### DIFF
--- a/.changeset/ten-wombats-deliver.md
+++ b/.changeset/ten-wombats-deliver.md
@@ -1,0 +1,23 @@
+---
+"@wuchale/vite-plugin": patch
+"wuchale": patch
+---
+
+Move the storage of plural rules to PO files and simplify config
+
+This makes sure that the po files are the single source
+of truth for translations as well as plural rules. The
+translator can update the rules as well. And for the language
+names, Intl.DisplayNames can be used and is more versatile.
+Then the only thing that needs to be specified in the config
+is the codes of the locales, nothing else. This makes the config
+simpler. To update your config, you have to have an array of the
+other locales' codes instead of an object for all locales. English
+will continue to be the `sourceLocale`.
+
+```js
+export default {
+  otherLocales: ['es', 'fr'],
+  adapters: ...
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,7 +1579,7 @@
         },
         "packages/vite-plugin": {
             "name": "@wuchale/vite-plugin",
-            "version": "0.10.0",
+            "version": "0.9.7",
             "license": "MIT",
             "dependencies": {
                 "wuchale": "^0.9.7"

--- a/packages/wuchale/src/cli/index.ts
+++ b/packages/wuchale/src/cli/index.ts
@@ -74,7 +74,7 @@ if (values.help) {
 } else if (cmd == null) {
     logger.info('Extracting...')
     const config = await getConfig(values.config)
-    const locales = Object.keys(config.locales)
+    const locales = [config.sourceLocale, ...config.otherLocales]
     for (const [key, adapter] of Object.entries(config.adapters)) {
         const handler = new AdapterHandler(adapter, key, config, 'extract', 'extract', process.cwd(), new Logger(config.messages))
         await extract(handler, locales)
@@ -83,6 +83,7 @@ if (values.help) {
 } else if (cmd === 'init') {
     logger.info('Initializing...')
     const config = await getConfig(values.config)
+    const locales = [config.sourceLocale, ...config.otherLocales]
     let extractedNew = false
     setupInteractive()
     const adapLogger = new Logger(config.messages)
@@ -102,7 +103,7 @@ if (values.help) {
         const loader = await ask(loaders, `Select default loader for adapter: ${key}`)
         await copyFile(adapter.defaultLoaderPath(loader), loaderPath)
         logger.log(`Initial extract for ${color.cyan(key)}`)
-        await extract(handler, Object.keys(config.locales))
+        await extract(handler, Object.keys(locales))
         extractedNew = true
     }
     const msgs = ['\nInitialization complete!\n']

--- a/packages/wuchale/src/config.ts
+++ b/packages/wuchale/src/config.ts
@@ -1,15 +1,9 @@
 import { resolve } from "node:path"
 import { type Adapter } from "./adapters.js"
 
-export type LocaleConf = {
-    name: string
-    nPlurals?: number
-    plural?: string
-}
-
 export type ConfigPartial = {
     sourceLocale?: string
-    locales?: {[locale: string]: LocaleConf}
+    otherLocales?: string[]
     geminiAPIKey?: string,
     messages?: boolean,
 }
@@ -21,21 +15,14 @@ export type Config = ConfigPartial & {
 
 export const defaultConfig: Config = {
     sourceLocale: 'en',
-    locales: {
-        en: {
-            name: 'English',
-            nPlurals: 2,
-            plural: 'n == 1 ? 0 : 1',
-        },
-    },
+    otherLocales: [],
     adapters: {},
     hmr: true,
     geminiAPIKey: 'env',
     messages: true,
 }
 
-// dynamicKeysInside is mainly to fill plural rules for other languages with English
-function deepAssign<Type>(fromObj: Type, toObj: Type, dynamicKeysInside: string[] = []) {
+function deepAssign<Type>(fromObj: Type, toObj: Type) {
     for (const [key, value] of Object.entries(fromObj)) {
         if (value === undefined) {
             delete toObj[key]
@@ -50,31 +37,15 @@ function deepAssign<Type>(fromObj: Type, toObj: Type, dynamicKeysInside: string[
         }
         deepAssign(fromObj[key], toObj[key])
     }
-    for (const key of dynamicKeysInside) {
-        const values = Object.values(toObj[key])
-        const defaultValEntries = Object.entries(values[0])
-        for (const val of values.slice(1)) {
-            for (const [k, defaultVal] of defaultValEntries) {
-                const v = val[k]
-                if (v != null) {
-                    continue
-                }
-                if (defaultVal == null) {
-                    throw Error(`At least the first option in ${key} should have ${k}`)
-                }
-                val[k] = defaultVal
-            }
-        }
-    }
 }
 
 export function defineConfig(config: Config) {
     return config
 }
 
-export function deepMergeObjects<Type>(source: Type, target: Type, dynamicKeysInside?: string[]): Type {
+export function deepMergeObjects<Type>(source: Type, target: Type): Type {
     const full = {...target}
-    deepAssign(source, full, dynamicKeysInside)
+    deepAssign(source, full)
     return full
 }
 
@@ -83,5 +54,5 @@ export const configName = 'wuchale.config.js'
 export async function getConfig(configPath?: string): Promise<Config> {
     const importPath = (configPath && resolve(configPath)) ?? `${process.cwd()}/${configName}`
     const module = await import(importPath)
-    return deepMergeObjects(module.default, defaultConfig, ['locales'])
+    return deepMergeObjects(module.default, defaultConfig)
 }

--- a/packages/wuchale/src/virtual.d.ts
+++ b/packages/wuchale/src/virtual.d.ts
@@ -11,7 +11,7 @@ declare module 'virtual:wuchale/proxy/sync' {
 }
 
 declare module 'virtual:wuchale/locales' {
-    export const locales: {[locale: string]: string}
+    export const locales: string[]
 }
 
 declare module 'virtual:wuchale/catalog/*' {


### PR DESCRIPTION
This makes sure that the po files are the single source of truth for translations as well as plural rules. The translator can update the rules as well. And for the language names, Intl.DisplayNames can be used and is more versatile. Then the only thing that needs to be specified in the config is the codes of the locales, nothing else. This makes the config simpler.

```js
export default {
    otherLocales: ['es', 'fr'],
    adapters: ...
}
```