### PR TITLE
fix: copy url translations without ai

### DIFF
--- a/packages/wuchale/src/handler/url.ts
+++ b/packages/wuchale/src/handler/url.ts
@@ -55,7 +55,7 @@ export class URLHandler {
             }
             item.translations.set(this.sourceLocale, [pattern])
             toCompile.push(item)
-            if (pattern.search(/\p{L}/u) === -1) {
+            if (!aiQueue || pattern.search(/\p{L}/u) === -1) {
                 for (const loc of this.locales) {
                     if (loc !== this.sourceLocale) {
                         item.translations.set(loc, [pattern])


### PR DESCRIPTION
While testing the new url extraction on main, I noticed that internationalizing urls does not work when translating via AI is not configured.

In this case the items that contain patterns to compile do not contain the patterns for other locales than the source locale.

There is special handling to not need translating urls containing no characters and I expanded the check to test if there is an ai queue configured.