### PR TITLE
fix export const runtime not defined error

### DIFF
--- a/packages/astro/CHANGELOG.md
+++ b/packages/astro/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @wuchale/astro
 
+## 0.3.3
+
+### Patch Changes
+
+- Fix `_w_runtime_ is not defined` crash when strings appear inside
+  `export const` declarations in frontmatter. Astro hoists exports to module
+  scope, but the runtime was initialized in component scope. Strings in
+  exports are now extracted for PO catalogs but the source code is left
+  unmutated, avoiding the dangling reference.
+
 ## 0.3.2
 
 ### Patch Changes

--- a/packages/astro/src/transformer.test.ts
+++ b/packages/astro/src/transformer.test.ts
@@ -211,3 +211,28 @@ test('Nested and mixed', async t => {
         ['Hello and <0>welcome to <0>the app {0}</0></0>!'],
     )
 })
+
+test('Export const declarations are not mutated (extract-only)', async t => {
+    // Bugfix: strings inside "export const" must be extracted for PO
+    // catalogs but the AST must NOT be mutated. Astro hoists exports to
+    // module scope where _w_runtime_ is undefined.
+    transformTest(
+        t,
+        await getOutput(astro`
+            ---
+            export const navigation = { title: 'Pricing' }
+            ---
+            <p>Hello</p>
+        `),
+        astro`
+            ---
+            import { _w_load_, _w_load_rx_ } from "./loader.js"
+            import _w_Tx_ from "@wuchale/astro/runtime.js"
+            const _w_runtime_ = _w_load_();
+            export const navigation = { title: 'Pricing' }
+            ---
+            <p>{_w_runtime_(0)}</p>
+        `,
+        ['Pricing', 'Hello'],
+    )
+})

--- a/packages/astro/src/transformer.ts
+++ b/packages/astro/src/transformer.ts
@@ -51,6 +51,7 @@ export class AstroTransformer extends Transformer {
     // state
     currentElement?: string | undefined
     inCompoundText: boolean = false
+    inExportDecl: boolean = false
     frontMatterStart?: number
 
     mixedVisitor: MixedVisitorAstro
@@ -299,6 +300,40 @@ export class AstroTransformer extends Transformer {
     }
 
     visitAs = (node: Node | AttributeNode | Estree.AnyNode): Message[] => this.visit(node as Estree.AnyNode)
+
+    // --- Overrides for export declarations ---
+    // Astro hoists "export const" to module scope, but _w_runtime_ lives in
+    // component scope. Extract strings for PO catalogs but leave the AST
+    // unmutated so we don't inject _w_runtime_ into module-scoped code.
+    override visitExportNamedDeclaration = (node: Estree.ExportNamedDeclaration): Message[] => {
+        if (!node.declaration) {
+            return []
+        }
+        this.inExportDecl = true
+        const msgs = this.visit(node.declaration)
+        this.inExportDecl = false
+        return msgs
+    }
+
+    override visitExportDefaultDeclaration = this.visitExportNamedDeclaration
+
+    override visitLiteral = (node: Estree.Literal, heuristicDetailsBase?: HeuristicDetailsBase): Message[] => {
+        if (typeof node.value !== 'string') {
+            return []
+        }
+        const { start, end } = node
+        const [pass, msgInfo] = this.checkHeuristic(node.value, heuristicDetailsBase ?? { scope: 'script' })
+        if (!pass) {
+            return []
+        }
+        // When inside an export declaration, extract for PO but do NOT mutate
+        // the export value — Astro hoists exports to module scope where
+        // _w_runtime_ is undefined.
+        if (!this.inExportDecl) {
+            this.mstr.update(start, end, this.literalRepl(msgInfo))
+        }
+        return [msgInfo]
+    }
 
     transformAs = async (): Promise<TransformOutput> => {
         const { ast } = await parse(this.content)


### PR DESCRIPTION
I had this bug in my project:

Strings inside `export const` declarations in `.astro` frontmatter cause a runtime crash because Astro's compiler hoists exports to module scope while `_w_runtime_` is initialized inside the component function scope.

Root cause: The transformer replaced string literals in exports (e.g. `title: 'Pricing' `→ `title: _w_runtime_(166)`) but the runtime variable is unreachable at module scope.

My Fix: Three overrides in `AstroTransformer`:

`visitExportNamedDeclaration` / `visitExportDefaultDeclaration` — set an `inExportDecl` flag before visiting children
`visitLiteral` — when the flag is set, extract the message for PO catalogs but skip the `mstr.update` that injects `_w_runtime_(N)`. Export declarations stay untouched in source; translations are compiled separately.

All 70 existing tests pass with no regressions.