### PR TITLE
svelte: extract svelte element children

### DIFF
--- a/.changeset/four-groups-sleep.md
+++ b/.changeset/four-groups-sleep.md
@@ -1,0 +1,5 @@
+---
+"@wuchale/svelte": patch
+---
+
+Visit `svelte:element`s as any other element

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -111,64 +111,6 @@ test('Simple element with new lines', async t => {
     )
 })
 
-test('Dynamic svelte element children', async t => {
-    transformTest(
-        t,
-        await getOutput(svelte`
-        <svelte:element this="span">
-            <span title="وصف">نص داخلي</span>
-        </svelte:element>
-    `),
-        svelte`
-        <script>
-            import { _w_load_, _w_load_rx_ } from "./loader.js"
-            import W_tx_ from "@wuchale/svelte/runtime.svelte"
-            const _w_runtime_ = $derived(_w_load_rx_());
-        </script>
-        <svelte:element this="span">
-            <span title={_w_runtime_(0)}>{_w_runtime_(1)}</span>
-        </svelte:element>
-    `,
-        ['وصف', 'نص داخلي'],
-    )
-})
-
-test('Dynamic svelte element in compound text', async t => {
-    transformTest(
-        t,
-        await getOutput(svelte`
-        <p>Hello <svelte:element this="span">world</svelte:element></p>
-    `),
-        svelte`
-        <script>
-            import { _w_load_, _w_load_rx_ } from "./loader.js"
-            import W_tx_ from "@wuchale/svelte/runtime.svelte"
-            const _w_runtime_ = $derived(_w_load_rx_());
-        </script>
-        <p>
-            {#snippet _w_snippet_0(_w_ctx_)}
-            <svelte:element this="span">{_w_runtime_.x(_w_ctx_)}</svelte:element>
-            {/snippet}
-            <W_tx_ t={[_w_snippet_0]} x={_w_runtime_.c(0)} />
-        </p>
-    `,
-        ['Hello <0>world</0>'],
-    )
-})
-
-test('Dynamic svelte element uses static tag context', async t => {
-    transformTest(
-        t,
-        await getOutput(svelte`
-        <svelte:element this="style">
-            color red
-        </svelte:element>
-    `),
-        undefined,
-        [],
-    )
-})
-
 test('Ignore and include', async t => {
     transformTest(
         t,
@@ -415,11 +357,11 @@ test('Tags and directives', async t => {
     )
 })
 
-test('Nested and mixed', async t => {
+test('Nested and mixed with svelte:element', async t => {
     transformTest(
         t,
         await getOutput(svelte`
-            <p>Hello and <b>welcome to <i>the app {appName}</i></b>!</p>
+            <p>Hello and <svelte:element this="b">welcome to <i>the app {appName}</i></svelte:element>!</p>
         `),
         svelte`
         <script>
@@ -429,18 +371,31 @@ test('Nested and mixed', async t => {
         </script>
         <p>
             {#snippet _w_snippet_1(_w_ctx_)}
-                <b>
-                {#snippet _w_snippet_0(_w_ctx_)}
-                    <i>
-                        <W_tx_ x={_w_ctx_} n a={[appName]} />
-                    </i>
-                {/snippet}
-                <W_tx_ t={[_w_snippet_0]} x={_w_ctx_} n />
-            </b>
+                <svelte:element this="b">
+                    {#snippet _w_snippet_0(_w_ctx_)}
+                        <i>
+                            <W_tx_ x={_w_ctx_} n a={[appName]} />
+                        </i>
+                    {/snippet}
+                    <W_tx_ t={[_w_snippet_0]} x={_w_ctx_} n />
+                </svelte:element>
             {/snippet}
             <W_tx_ t={[_w_snippet_1]} x={_w_runtime_.c(0)} />
         </p>
     `,
         ['Hello and <0>welcome to <0>the app {0}</0></0>!'],
+    )
+})
+
+test('svelte:element uses static tag context', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+        <svelte:element this="style">
+            color red
+        </svelte:element>
+    `),
+        undefined,
+        [],
     )
 })

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -111,6 +111,64 @@ test('Simple element with new lines', async t => {
     )
 })
 
+test('Dynamic svelte element children', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+        <svelte:element this="span">
+            <span title="وصف">نص داخلي</span>
+        </svelte:element>
+    `),
+        svelte`
+        <script>
+            import { _w_load_, _w_load_rx_ } from "./loader.js"
+            import W_tx_ from "@wuchale/svelte/runtime.svelte"
+            const _w_runtime_ = $derived(_w_load_rx_());
+        </script>
+        <svelte:element this="span">
+            <span title={_w_runtime_(0)}>{_w_runtime_(1)}</span>
+        </svelte:element>
+    `,
+        ['وصف', 'نص داخلي'],
+    )
+})
+
+test('Dynamic svelte element in compound text', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+        <p>Hello <svelte:element this="span">world</svelte:element></p>
+    `),
+        svelte`
+        <script>
+            import { _w_load_, _w_load_rx_ } from "./loader.js"
+            import W_tx_ from "@wuchale/svelte/runtime.svelte"
+            const _w_runtime_ = $derived(_w_load_rx_());
+        </script>
+        <p>
+            {#snippet _w_snippet_0(_w_ctx_)}
+            <svelte:element this="span">{_w_runtime_.x(_w_ctx_)}</svelte:element>
+            {/snippet}
+            <W_tx_ t={[_w_snippet_0]} x={_w_runtime_.c(0)} />
+        </p>
+    `,
+        ['Hello <0>world</0>'],
+    )
+})
+
+test('Dynamic svelte element uses static tag context', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+        <svelte:element this="style">
+            color red
+        </svelte:element>
+    `),
+        undefined,
+        [],
+    )
+})
+
 test('Ignore and include', async t => {
     transformTest(
         t,

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -24,7 +24,7 @@ import { getKey } from 'wuchale'
 import { MixedVisitor, nonWhitespaceText, varNames } from 'wuchale/adapter-utils'
 import { parseScript, Transformer } from 'wuchale/adapter-vanilla'
 
-const nodesWithChildren = ['RegularElement', 'Component']
+const nodesWithChildren = ['RegularElement', 'Component', 'SvelteElement']
 const noWrapTopCalls = ['$props', '$state', '$derived', '$effect']
 
 const rtComponent = 'W_tx_'
@@ -32,7 +32,7 @@ const headerAdd = `\nimport ${rtComponent} from "@wuchale/svelte/runtime.svelte"
 const snipPrefix = '_w_snippet_'
 const rtModuleVar = `${varNames.rt}mod_`
 
-type MixedNodesTypes = AST.Text | AST.Tag | AST.ElementLike | AST.Block | AST.Comment
+type MixedNodesTypes = AST.Text | AST.Tag | AST.ElementLike | AST.SvelteElement | AST.Block | AST.Comment
 type MixedVisitorSvelte = MixedVisitor<MixedNodesTypes, AST.Text, AST.Comment, AST.ExpressionTag>
 
 // for use before actually parsing the code,
@@ -329,7 +329,20 @@ export class SvelteTransformer extends Transformer {
 
     visitSvelteDocument = (node: AST.SvelteDocument): Message[] => node.attributes.flatMap(this.visitSv)
 
-    visitSvelteElement = (node: AST.SvelteElement): Message[] => node.attributes.flatMap(this.visitSv)
+    getSvelteElementName = (node: AST.SvelteElement): string => {
+        if (node.tag.type === 'Literal' && typeof node.tag.value === 'string') {
+            return node.tag.value
+        }
+        return 'svelte:element'
+    }
+
+    visitSvelteElement = (node: AST.SvelteElement): Message[] => {
+        const currentElement = this.currentElement
+        this.currentElement = this.getSvelteElementName(node)
+        const msgs = [...node.attributes.flatMap(this.visitSv), ...this.visitFragment(node.fragment)]
+        this.currentElement = currentElement
+        return msgs
+    }
 
     visitSvelteBoundary = (node: AST.SvelteBoundary): Message[] => [
         ...node.attributes.flatMap(this.visitSv),

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -329,16 +329,13 @@ export class SvelteTransformer extends Transformer {
 
     visitSvelteDocument = (node: AST.SvelteDocument): Message[] => node.attributes.flatMap(this.visitSv)
 
-    getSvelteElementName = (node: AST.SvelteElement): string => {
-        if (node.tag.type === 'Literal' && typeof node.tag.value === 'string') {
-            return node.tag.value
-        }
-        return 'svelte:element'
-    }
-
     visitSvelteElement = (node: AST.SvelteElement): Message[] => {
         const currentElement = this.currentElement
-        this.currentElement = this.getSvelteElementName(node)
+        if (node.tag.type === 'Literal' && typeof node.tag.value === 'string') {
+            this.currentElement = node.tag.value
+        } else {
+            this.currentElement = 'svelte:element'
+        }
         const msgs = [...node.attributes.flatMap(this.visitSv), ...this.visitFragment(node.fragment)]
         this.currentElement = currentElement
         return msgs


### PR DESCRIPTION
## Summary
- Treat SvelteElement as a child-bearing markup node in mixed Svelte fragments
- Add a regression test for `<svelte:element>` inside compound text

## Root Cause
`visitSvelteElement` visited dynamic element children, but the mixed visitor still classified nested `SvelteElement` nodes as leaf placeholders, so parent compound messages lost their child text.

## Validation
- `pnpm exec tsc -p packages/wuchale/tsconfig.build.json --sourceMap false --declarationMap false --strictNullChecks true`
- `pnpm exec tsc -p packages/svelte/tsconfig.build.json --sourceMap false --declarationMap false --strictNullChecks true`
- `pnpm --dir packages/svelte test`

Note: the repo build config currently requires the explicit `--strictNullChecks true` override because `exactOptionalPropertyTypes` is set without `strictNullChecks`.