### PR TITLE
feat: extract template literals starting with placeholder + natural language

### DIFF
--- a/.changeset/fix-placeholder-prefix-heuristic.md
+++ b/.changeset/fix-placeholder-prefix-heuristic.md
@@ -1,0 +1,7 @@
+---
+"wuchale": minor
+---
+
+Extract template literals that start with a placeholder expression followed by natural language content.
+
+Strings like `` `${name} was successfully deleted!` `` (compiled to `{0} was successfully deleted!`) were previously ignored by the heuristic because the first character `{` is not a letter. They are now extracted when the leading placeholder is followed by a space or `'s`, which strongly indicates user-facing natural language rather than a structural/technical string.

--- a/.changeset/fix-placeholder-prefix-heuristic.md
+++ b/.changeset/fix-placeholder-prefix-heuristic.md
@@ -4,4 +4,6 @@
 
 Extract template literals that start with a placeholder expression followed by natural language content.
 
-Strings like `` `${name} was successfully deleted!` `` (compiled to `{0} was successfully deleted!`) were previously ignored by the heuristic because the first character `{` is not a letter. They are now extracted when the leading placeholder is followed by a space or `'s`, which strongly indicates user-facing natural language rather than a structural/technical string.
+Messages like `{0} was successfully deleted!` were previously ignored because
+the first character `{` is not a letter. They are now
+extracted when the leading placeholder is followed by spaces and letters.

--- a/packages/wuchale/src/adapters.test.ts
+++ b/packages/wuchale/src/adapters.test.ts
@@ -22,7 +22,7 @@ test('heuristic: template literal starting with placeholder + space is extracted
     t.assert.equal(heuristic(scriptMsg('{0} was successfully deleted!')), 'message')
 })
 
-test("heuristic: template literal starting with placeholder + 's is extracted", t => {
+test("heuristic: template literal starting with placeholder + 's<space> is extracted", t => {
     // `${user.email}'s role was updated` → wuchale msgStr: `{0}'s role was updated`
     t.assert.equal(heuristic(scriptMsg("{0}'s role was updated to administrator.")), 'message')
 })

--- a/packages/wuchale/src/adapters.test.ts
+++ b/packages/wuchale/src/adapters.test.ts
@@ -17,30 +17,11 @@ function scriptMsg(msgStr: string) {
     })
 }
 
-test('heuristic: template literal starting with placeholder + space is extracted', t => {
-    // `${name} was successfully deleted!` → wuchale msgStr: `{0} was successfully deleted!`
+test('Default heuristic checks correct', t => {
     t.assert.equal(heuristic(scriptMsg('{0} was successfully deleted!')), 'message')
-})
-
-test("heuristic: template literal starting with placeholder + 's<space> is extracted", t => {
-    // `${user.email}'s role was updated` → wuchale msgStr: `{0}'s role was updated`
     t.assert.equal(heuristic(scriptMsg("{0}'s role was updated to administrator.")), 'message')
-})
-
-test('heuristic: plain template literal starting with path-like expression is NOT extracted', t => {
-    // `${base}/api/users` — structural, not translatable
     t.assert.equal(heuristic(scriptMsg('{0}/api/users')), false)
-})
-
-test('heuristic: plain template literal with only expression and dot is NOT extracted', t => {
-    // `${obj.key}` — no natural language
     t.assert.equal(heuristic(scriptMsg('{0}')), false)
-})
-
-test('heuristic: normal uppercase-starting script string is extracted', t => {
     t.assert.equal(heuristic(scriptMsg('Hello world')), 'message')
-})
-
-test('heuristic: lowercase-starting script string is NOT extracted', t => {
     t.assert.equal(heuristic(scriptMsg('someVariable')), false)
 })

--- a/packages/wuchale/src/adapters.test.ts
+++ b/packages/wuchale/src/adapters.test.ts
@@ -1,0 +1,46 @@
+// $ node --import ../testing/resolve.ts %f
+
+import { test } from 'node:test'
+import { createHeuristic, defaultHeuristicOpts, newMessage } from './adapters.js'
+
+const heuristic = createHeuristic(defaultHeuristicOpts)
+
+function scriptMsg(msgStr: string) {
+    return newMessage({
+        msgStr: [msgStr],
+        details: {
+            file: 'test.ts',
+            scope: 'script',
+            insideProgram: true,
+            funcName: 'myFn',
+        },
+    })
+}
+
+test('heuristic: template literal starting with placeholder + space is extracted', t => {
+    // `${name} was successfully deleted!` → wuchale msgStr: `{0} was successfully deleted!`
+    t.assert.equal(heuristic(scriptMsg('{0} was successfully deleted!')), 'message')
+})
+
+test("heuristic: template literal starting with placeholder + 's is extracted", t => {
+    // `${user.email}'s role was updated` → wuchale msgStr: `{0}'s role was updated`
+    t.assert.equal(heuristic(scriptMsg("{0}'s role was updated to administrator.")), 'message')
+})
+
+test('heuristic: plain template literal starting with path-like expression is NOT extracted', t => {
+    // `${base}/api/users` — structural, not translatable
+    t.assert.equal(heuristic(scriptMsg('{0}/api/users')), false)
+})
+
+test('heuristic: plain template literal with only expression and dot is NOT extracted', t => {
+    // `${obj.key}` — no natural language
+    t.assert.equal(heuristic(scriptMsg('{0}')), false)
+})
+
+test('heuristic: normal uppercase-starting script string is extracted', t => {
+    t.assert.equal(heuristic(scriptMsg('Hello world')), 'message')
+})
+
+test('heuristic: lowercase-starting script string is NOT extracted', t => {
+    t.assert.equal(heuristic(scriptMsg('someVariable')), false)
+})

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -116,7 +116,14 @@ export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
         //  non-letter beginnings
         //  lower-case English letter beginnings
         //  containing only upper-case English and non-letters
-        if (!/\p{L}/u.test(msgStr[0]!) || /[a-z]/.test(msgStr[0]!) || /^([A-Z]|\P{L})+$/u.test(msgStr)) {
+        //
+        // Exception: template literals that begin with a placeholder expression
+        // followed by a space or "'s " are natural language strings and should
+        // be extracted.  e.g. `${name} was deleted!` becomes `{0} was deleted!`
+        // — the leading `{0}` is not a letter, but the string is clearly
+        // translatable user-facing content.
+        const startsWithPlaceholderPhrase = /^\{\d+\}(?:\s|'s[\s,!.])/.test(msgStr)
+        if (!startsWithPlaceholderPhrase && (!/\p{L}/u.test(msgStr[0]!) || /[a-z]/.test(msgStr[0]!) || /^([A-Z]|\P{L})+$/u.test(msgStr))) {
             return false
         }
         if (msg.details.scope === 'attribute') {

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -122,7 +122,7 @@ export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
         // be extracted.  e.g. `${name} was deleted!` becomes `{0} was deleted!`
         // — the leading `{0}` is not a letter, but the string is clearly
         // translatable user-facing content.
-        const startsWithPlaceholderPhrase = /^\{\d+\}(?:\s|'s[\s,!.])/.test(msgStr)
+        const startsWithPlaceholderPhrase = /^\{\d+\}(?:\s|'s\s)/.test(msgStr)
         if (!startsWithPlaceholderPhrase && (!/\p{L}/u.test(msgStr[0]!) || /[a-z]/.test(msgStr[0]!) || /^([A-Z]|\P{L})+$/u.test(msgStr))) {
             return false
         }

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -112,18 +112,18 @@ export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
             return 'message'
         }
         // script and attribute
-        // ignore:
-        //  non-letter beginnings
-        //  lower-case English letter beginnings
-        //  containing only upper-case English and non-letters
-        //
-        // Exception: template literals that begin with a placeholder expression
-        // followed by a space or "'s " are natural language strings and should
-        // be extracted.  e.g. `${name} was deleted!` becomes `{0} was deleted!`
-        // — the leading `{0}` is not a letter, but the string is clearly
-        // translatable user-facing content.
-        const startsWithPlaceholderPhrase = /^\{\d+\}(?:\s|'s\s)/.test(msgStr)
-        if (!startsWithPlaceholderPhrase && (!/\p{L}/u.test(msgStr[0]!) || /[a-z]/.test(msgStr[0]!) || /^([A-Z]|\P{L})+$/u.test(msgStr))) {
+        if (/^([A-Z]|\P{L})+$/u.test(msgStr)) {
+            // only upper-case English and non-letters
+            return false
+        }
+        if (/^\{\d+\}/.test(msgStr)) {
+            // template literals that begin with a placeholder expression
+            if (!/\s\p{L}/u.test(msgStr)) {
+                // should contain spaces and letters
+                return false
+            }
+        } else if (/[a-z]|\P{L}/u.test(msgStr[0]!)) {
+            // ignore non-letter and lower-case English beginnings
             return false
         }
         if (msg.details.scope === 'attribute') {


### PR DESCRIPTION
## Problem

Closes #362.

Template literals that begin with an interpolated expression followed by a space or `'s` — the most common natural-language-with-subject pattern — are not extracted by the default heuristic.

Example strings that were silently skipped:
```ts
// `${organization.name} was successfully deleted!`
// wuchale sees: `{0} was successfully deleted!`
// first char = `{` → not a letter → ignored ✗

// `${user.email}'s role was updated to ${role}.`
// wuchale sees: `{0}'s role was updated to {1}.`
// first char = `{` → ignored ✗
```

The only workaround was adding `// @wc-include` above every affected string.

## Fix

Add a pattern check in `createHeuristic` before the non-letter guard:

```ts
const startsWithPlaceholderPhrase = /^\{\d+\}(?:\s|'s[\s,!.])/.test(msgStr)
if (!startsWithPlaceholderPhrase && (!/\p{L}/u.test(msgStr[0]!) || ...)) {
    return false
}
```

Structural strings that start with `{0}` but aren't natural language — paths (`{0}/api`), query strings (`{0}?id=`), class names, filenames — are still excluded because they don't match `{N}<space>` or `{N}'s`.

## Tests

Added `packages/wuchale/src/adapters.test.ts` with 6 cases:
- ✅ `{0} was successfully deleted!` → extracted
- ✅ `{0}'s role was updated` → extracted
- ❌ `{0}/api/users` → not extracted (path)
- ❌ `{0}` → not extracted (bare expression)
- ✅ `Hello world` → extracted (existing behaviour preserved)
- ❌ `someVariable` → not extracted (existing behaviour preserved)