### PR TITLE
More dev modes

### DIFF
--- a/.changeset/loud-bars-pick.md
+++ b/.changeset/loud-bars-pick.md
@@ -5,8 +5,10 @@
 "@wuchale/jsx": patch
 ---
 
-⚠️ BREAKING: Rename config `hmr` to `dev` with the options `'full' | 'read' | false` to control behavior during dev:
+⚠️ BREAKING: Rename config `hmr` to `dev` with the following options to control behavior during dev:
 
-- `'full'`: Same behavior as the previous `hmr: true`
-- `'read'`: Only uses existing translations and doesn't add newly detected messages during dev
 - `false`: Same behavior as the previous `hmr: false`
+- `'read'`: Only uses existing translations and doesn't add newly detected messages during dev
+- `'add'`: Adds newly detected messages and updates their refs as they get referenced, but doesn't touch existing messages
+- `'refs'`: Same behavior as the previous `hmr: true`, adds new messages, updates refs and marks obsoletes
+- `'clean'`: Full behavior same as `npx wuchale --clean`, deletes unused messages

--- a/packages/wuchale/src/config.ts
+++ b/packages/wuchale/src/config.ts
@@ -12,9 +12,11 @@ export type ConfigPartial = {
     logLevel: LogLevel
 }
 
+export type DevMode = false | 'read' | 'add' | 'refs' | 'clean'
+
 export type Config = ConfigPartial & {
     adapters: Record<string, Adapter>
-    dev: 'full' | 'read' | false
+    dev: DevMode
 }
 
 export type DeepPartial<T> = {
@@ -34,7 +36,7 @@ export const defaultConfig: Config = {
     fallback: {},
     localesDir: 'src/locales',
     adapters: {},
-    dev: 'full',
+    dev: 'refs',
     ai: defaultGemini,
     logLevel: 'info',
 }

--- a/packages/wuchale/src/handler/index.test.ts
+++ b/packages/wuchale/src/handler/index.test.ts
@@ -43,7 +43,7 @@ async function makeHandler() {
         log: new Logger('error'),
         sourceLocale: 'en',
         sharedState: new SharedState(storage, 'test', 'en', true),
-        modifyCatalogs: true,
+        devMode: 'refs',
         modifyInplace: false,
     })
 }

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -7,7 +7,7 @@ import type { Adapter, Message, RuntimeExpr, TransformOutputCode } from '../adap
 import { getKey } from '../adapters.js'
 import AIQueue from '../ai/index.js'
 import { type CompiledElement, compileTranslation } from '../compile.js'
-import type { ConfigPartial } from '../config.js'
+import type { ConfigPartial, DevMode } from '../config.js'
 import type { Logger } from '../log.js'
 import type { HMRData } from '../runtime.js'
 import { type FileRef, type FileRefEntry, type Item, itemIsUrl, newItem } from '../storage.js'
@@ -55,6 +55,8 @@ export function getLoadIDs(adapter: Adapter, granularStates: Iterable<GranularSt
     return loadIDs
 }
 
+export const newItemsAllowed = (devMode: DevMode) => devMode === 'add' || devMode === 'refs' || devMode === 'clean'
+
 function getFallback(
     fbConf: Record<string, string>,
     loc: string,
@@ -95,7 +97,7 @@ type HandlerOptsCreate = FilesOptsCreatePass & {
     log: Logger
     sourceLocale: string
     sharedState: SharedState
-    modifyCatalogs: boolean
+    devMode: DevMode
     modifyInplace: boolean
 }
 
@@ -117,6 +119,7 @@ export class AdapterHandler {
     readonly aiQueue?: AIQueue
     onBeforeSave?: () => void
     #fallbackChains: Map<string, string[]>
+    #newKeys = new Set<string>() // keys added during dev
 
     private constructor(opts: HandlerOpts) {
         this.#opts = opts
@@ -171,7 +174,7 @@ export class AdapterHandler {
 
     saveStorage = async () => {
         this.onBeforeSave?.()
-        await this.sharedState.save()
+        await this.sharedState.save(this.#opts.mode === 'dev' && this.#opts.devMode === 'clean')
     }
 
     compile = async (hmrVersion = -1) => {
@@ -314,7 +317,7 @@ export class AdapterHandler {
                     const state = await this.granularState.byFileCreate(
                         ref.file,
                         this.#opts.config.locales,
-                        this.#opts.modifyCatalogs,
+                        newItemsAllowed(this.#opts.devMode),
                     )
                     const compiledLoc = state.compiled.get(loc)!
                     compiledLoc.hasPlurals = sharedCompiledLoc.hasPlurals
@@ -479,6 +482,8 @@ export class AdapterHandler {
         let compileUpdated = false
         const hmrKeys: string[] = []
         const toTranslate: Item[] = []
+        const modifyExistingRefs =
+            this.#opts.mode !== 'dev' || this.#opts.devMode === 'refs' || this.#opts.devMode === 'clean'
         for (const msgInfo of msgs) {
             let key = getKey(msgInfo.msgStr, msgInfo.context)
             hmrKeys.push(key)
@@ -495,10 +500,12 @@ export class AdapterHandler {
             if (!item) {
                 item = newItem({ id: msgInfo.msgStr }, this.#opts.config.locales)
                 this.sharedState.catalog.set(key, item)
+                this.#newKeys.add(key)
                 storageUpdated = true
                 compileUpdated = true
             }
-            if (this.updateRef(item, key, filename, msgInfo, previousReferences)) {
+            const modifyRefs = modifyExistingRefs || (this.#opts.devMode === 'add' && this.#newKeys.has(key))
+            if (modifyRefs && this.updateRef(item, key, filename, msgInfo, previousReferences)) {
                 storageUpdated = true
                 if (msgInfo.type === 'url') {
                     compileUpdated = true
@@ -528,16 +535,18 @@ export class AdapterHandler {
             this.aiQueue.add(toTranslate)
             await this.aiQueue.running
         }
-        const { cleaned, cleanedUrls } = this.cleanTrackedRefs(previousReferences)
-        if (cleaned) {
-            storageUpdated = true
-        }
-        if (cleanedUrls) {
-            compileUpdated = true
+        if (modifyExistingRefs) {
+            const { cleaned, cleanedUrls } = this.cleanTrackedRefs(previousReferences)
+            if (cleaned) {
+                storageUpdated = true
+            }
+            if (cleanedUrls) {
+                compileUpdated = true
+            }
         }
         // cli saves and compiles at the end
         if (storageUpdated && this.#opts.mode !== 'cli') {
-            this.#opts.modifyCatalogs && (await this.saveStorage())
+            this.#opts.devMode && (await this.saveStorage())
             if (compileUpdated) {
                 await this.compile()
             }
@@ -559,7 +568,7 @@ export class AdapterHandler {
             const state = await this.granularState.byFileCreate(
                 filename,
                 this.#opts.config.locales,
-                this.#opts.modifyCatalogs,
+                newItemsAllowed(this.#opts.devMode),
             )
             indexTracker = state.indexTracker
             loadID = state.id

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -55,7 +55,8 @@ export function getLoadIDs(adapter: Adapter, granularStates: Iterable<GranularSt
     return loadIDs
 }
 
-export const newItemsAllowed = (devMode: DevMode) => devMode === 'add' || devMode === 'refs' || devMode === 'clean'
+export const newItemsAllowed = (mode: Mode, devMode: DevMode) =>
+    mode !== 'dev' || devMode === 'add' || devMode === 'refs' || devMode === 'clean'
 
 function getFallback(
     fbConf: Record<string, string>,
@@ -317,7 +318,7 @@ export class AdapterHandler {
                     const state = await this.granularState.byFileCreate(
                         ref.file,
                         this.#opts.config.locales,
-                        newItemsAllowed(this.#opts.devMode),
+                        newItemsAllowed(this.#opts.mode, this.#opts.devMode),
                     )
                     const compiledLoc = state.compiled.get(loc)!
                     compiledLoc.hasPlurals = sharedCompiledLoc.hasPlurals
@@ -568,7 +569,7 @@ export class AdapterHandler {
             const state = await this.granularState.byFileCreate(
                 filename,
                 this.#opts.config.locales,
-                newItemsAllowed(this.#opts.devMode),
+                newItemsAllowed(this.#opts.mode, this.#opts.devMode),
             )
             indexTracker = state.indexTracker
             loadID = state.id

--- a/packages/wuchale/src/handler/state.ts
+++ b/packages/wuchale/src/handler/state.ts
@@ -1,7 +1,14 @@
 import pm from 'picomatch'
 import { getKey, IndexTracker, type LoadGroupPatt } from '../adapters.js'
 import type { CompiledElement } from '../compile.js'
-import { type Catalog, type CatalogStorage, defaultPluralRule, fillTranslations, type PluralRules } from '../storage.js'
+import {
+    type Catalog,
+    type CatalogStorage,
+    defaultPluralRule,
+    fillTranslations,
+    itemIsObsolete,
+    type PluralRules,
+} from '../storage.js'
 
 export type Compiled = {
     hasPlurals: boolean
@@ -43,11 +50,11 @@ export class SharedState {
     catalog: Catalog = new Map()
     pluralRules: PluralRules = new Map()
 
-    constructor(storage: CatalogStorage, ownerKey: string, sourceLocale: string, modifyCatalogs: boolean) {
+    constructor(storage: CatalogStorage, ownerKey: string, sourceLocale: string, allowNewItems: boolean) {
         this.ownerKey = ownerKey
         this.sourceLocale = sourceLocale
         this.storage = storage
-        this.indexTracker = new IndexTracker(modifyCatalogs)
+        this.indexTracker = new IndexTracker(allowNewItems)
     }
 
     async load(locales: string[]) {
@@ -70,11 +77,11 @@ export class SharedState {
         }
     }
 
-    async save() {
+    async save(onlyReferenced: boolean) {
+        const items = Array.from(this.catalog.values())
         await this.storage.save({
             pluralRules: this.pluralRules,
-            // Array important, cannot loop over map values multiple times!
-            items: Array.from(this.catalog.values()),
+            items: onlyReferenced ? items.filter(i => !itemIsObsolete(i)) : items,
         })
     }
 }
@@ -117,7 +124,7 @@ export class State {
         return id + 1 // not to start from 0 which is reserved for the shared
     }
 
-    async byFileCreate(filename: string, locales: string[], modifyCatalogs: boolean): Promise<GranularState> {
+    async byFileCreate(filename: string, locales: string[], allowNewItems: boolean): Promise<GranularState> {
         let state = this.#byFile.get(filename)
         if (state != null) {
             return state
@@ -128,7 +135,7 @@ export class State {
             state = {
                 id,
                 compiled: new Map(),
-                indexTracker: new IndexTracker(modifyCatalogs),
+                indexTracker: new IndexTracker(allowNewItems),
             }
             for (const loc of locales) {
                 state.compiled.set(loc, { hasPlurals: false, items: [] })

--- a/packages/wuchale/src/hub.test.ts
+++ b/packages/wuchale/src/hub.test.ts
@@ -5,7 +5,7 @@ import { type TestContext, test } from 'node:test'
 // @ts-expect-error
 import { dummyTransform, inMemFS, trimLines, ts } from '../../wuchale/testing/utils.ts'
 import { defaultArgs } from './adapter-vanilla/index.js'
-import { type Config, defaultConfig } from './config.js'
+import { type Config, type DevMode, defaultConfig } from './config.js'
 import { generatedDir, normalizeSep } from './handler/files.js'
 import { Hub } from './hub.js'
 
@@ -17,10 +17,17 @@ const code = ts`
     }
 `
 
+const transformedCodeDefault = ts`
+    import {getRuntime as _w_load_, getRuntimeRx as _w_load_rx_} from "./locales/main.loader.js"
+    _w_load_()(0)
+`
+
 const defaultLoaderPath = {
     client: '/loaders/loader.js',
     server: '/loaders/loader.server.js',
 }
+
+let devMode: DevMode = 'refs'
 
 const loadConfig = async (): Promise<Config> => ({
     ...defaultConfig,
@@ -33,6 +40,7 @@ const loadConfig = async (): Promise<Config> => ({
             defaultLoaderPath,
         },
     },
+    dev: devMode,
 })
 
 inMemFS.write(defaultLoaderPath.client, '')
@@ -41,13 +49,7 @@ const hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMe
 
 test('hub transform basic', async (t: TestContext) => {
     const [output] = await hub.transform(code, file)
-    t.assert.strictEqual(
-        trimLines(output.code),
-        trimLines(ts`
-            import {getRuntime as _w_load_, getRuntimeRx as _w_load_rx_} from "./locales/main.loader.js"
-            _w_load_()(0)
-        `),
-    )
+    t.assert.strictEqual(trimLines(output.code), trimLines(transformedCodeDefault))
 })
 
 test('hub transform ssr', async (t: TestContext) => {
@@ -96,4 +98,50 @@ test('hub transform with hmr', async (t: TestContext) => {
         _w_load_()(0)
     `),
     )
+})
+
+test('different dev modes', async (t: TestContext) => {
+    const po = resolve(import.meta.dirname, 'src/locales/en.po')
+
+    await inMemFS.unlink(po)
+    devMode = false
+    let hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMemFS)
+    const [output] = await hub.transform(code, file)
+    t.assert.strictEqual(await inMemFS.read(po), null)
+    t.assert.deepStrictEqual(output, {})
+
+    // existing po
+    devMode = 'add'
+    hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMemFS)
+    await hub.transform(code, file)
+    await hub.transform(ts`const x = () => 'Hello1'`, file)
+    let poContent = (await inMemFS.read(po)) ?? ''
+    t.assert.match(poContent, /\nmsgid "Hello"/)
+    t.assert.match(poContent, /\nmsgid "Hello1"/)
+
+    // existing po
+    devMode = 'read'
+    hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMemFS)
+    await hub.transform(ts`const x = () => 'Hello2'`, file)
+    poContent = (await inMemFS.read(po)) ?? ''
+    t.assert.match(poContent, /"Hello"/)
+    t.assert.match(poContent, /"Hello1"/)
+    t.assert.doesNotMatch(poContent, /"Hello2"/)
+
+    await inMemFS.unlink(po)
+    devMode = 'refs'
+    hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMemFS)
+    await hub.transform(code, file)
+    await hub.transform(ts`const x = () => 'Hello1'`, file)
+    poContent = (await inMemFS.read(po)) ?? ''
+    t.assert.match(poContent, /\n#~ msgid "Hello"/) // obsolete
+    t.assert.match(poContent, /\nmsgid "Hello1"/) // new
+
+    // existing po
+    devMode = 'clean'
+    hub = await Hub.create('dev', loadConfig, import.meta.dirname, [], 0, inMemFS)
+    await hub.transform(code, file)
+    poContent = (await inMemFS.read(po)) ?? ''
+    t.assert.match(poContent, /"Hello"/)
+    t.assert.doesNotMatch(poContent, /"Hello1"/)
 })

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -10,7 +10,7 @@ import { compileTranslation, isEquivalent } from './compile.js'
 import type { Config } from './config.js'
 import { defaultFS, type FS } from './fs.js'
 import { dataFileName, generatedDir, getLoaderPath, globConfToArgs, normalizeSep } from './handler/files.js'
-import { AdapterHandler, getLoadIDs, type Mode } from './handler/index.js'
+import { AdapterHandler, getLoadIDs, type Mode, newItemsAllowed } from './handler/index.js'
 import { SharedState } from './handler/state.js'
 import { color, Logger } from './log.js'
 import { itemIsObsolete, itemIsUrl } from './storage.js'
@@ -98,7 +98,7 @@ async function getSharedState(
     adapter: Adapter,
     key: string,
     sourceLocale: string,
-    modifyCatalogs: boolean,
+    allowNewItems: boolean,
 ): Promise<SharedState> {
     const storage = await adapter.storage({
         locales: config.locales,
@@ -109,7 +109,7 @@ async function getSharedState(
     })
     let sharedState = sharedStates.get(storage.key)
     if (sharedState == null) {
-        sharedState = new SharedState(storage, key, sourceLocale, modifyCatalogs)
+        sharedState = new SharedState(storage, key, sourceLocale, allowNewItems)
         sharedStates.set(storage.key, sharedState)
     } else {
         if (sharedState.sourceLocale !== sourceLocale) {
@@ -216,7 +216,6 @@ export class Hub {
         const sharedStates = new Map<string, SharedState>()
         const handlers = new Map<string, AdapterHandler>()
         const commonOpts = { config, mode, fs, root, log }
-        const modifyCatalogs = mode !== 'dev' || config.dev === 'full'
         for (const [key, adapter] of adaptersData) {
             const sourceLocale = adapter.sourceLocale ?? config.locales[0]
             const handler = await AdapterHandler.create({
@@ -232,9 +231,9 @@ export class Hub {
                     adapter,
                     key,
                     sourceLocale,
-                    modifyCatalogs,
+                    newItemsAllowed(config.dev),
                 ),
-                modifyCatalogs,
+                devMode: config.dev,
                 modifyInplace: modifyAdapters.includes(key),
             })
             handlers.set(key, handler)

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -231,7 +231,7 @@ export class Hub {
                     adapter,
                     key,
                     sourceLocale,
-                    newItemsAllowed(config.dev),
+                    newItemsAllowed(mode, config.dev),
                 ),
                 devMode: config.dev,
                 modifyInplace: modifyAdapters.includes(key),

--- a/packages/wuchale/testing/utils.ts
+++ b/packages/wuchale/testing/utils.ts
@@ -1,7 +1,7 @@
 import { statfs } from 'node:fs/promises'
 import type { TestContext } from 'node:test'
 import { getDefaultLoaderPath } from '../src/adapter-vanilla/index.js'
-import { type Message, newMessage, type TransformFunc, type TransformOutput } from '../src/adapters.js'
+import { getKey, type Message, newMessage, type TransformFunc, type TransformOutput } from '../src/adapters.js'
 import type { FS } from '../src/fs.js'
 import type { SaveData, StorageFactory } from '../src/storage.js'
 
@@ -75,10 +75,18 @@ export const testLoadersExist = async (loaders: string[], getLoaderPath = getDef
 }
 
 export const dummyTransform: TransformFunc = ctx => {
-    const msg = 'Hello'
-    const out = `${ctx.expr.plain}(${ctx.index.get(msg)})`
+    const msgs: Message[] = []
+    let out = ''
+    for (const m of ctx.content.matchAll(/'\w+'/g)) {
+        const msg = m[0].slice(1, -1)
+        if (!ctx.index.has(getKey([msg]))) {
+            continue
+        }
+        out += `${ctx.expr.plain}(${ctx.index.get(msg)})\n`
+        msgs.push(newMessage({ msgStr: [msg] }))
+    }
     return {
-        msgs: [newMessage({ msgStr: [msg] })],
+        msgs,
         output: header => ({
             code: `${header}\n${out}`,
             map: [],


### PR DESCRIPTION
This adds more `dev` modes, so the final selection will be `false | 'read' | 'add' | 'refs' | 'clean'`, from no involvement to cleaning unused items.

Closes #376 