### PR TITLE
Redo nested message source modification order

### DIFF
--- a/.changeset/twenty-taxes-bake.md
+++ b/.changeset/twenty-taxes-bake.md
@@ -1,0 +1,10 @@
+---
+"wuchale": minor
+"@wuchale/svelte": patch
+"@wuchale/astro": patch
+"@wuchale/jsx": patch
+---
+
+Redo nested message visit algorithm
+
+This release is all about the core of wuchale, i.e. the nested message visitor. It has now been vastly improved with a more solid approach.

--- a/packages/astro/src/runtime.ts
+++ b/packages/astro/src/runtime.ts
@@ -3,11 +3,11 @@ import type { Composite } from 'wuchale'
 export type WuchaleComponentProps = {
     n?: boolean
     x: Composite
-    t: ((...a: any[]) => any)[]
+    t?: ((...a: any[]) => any)[]
     a?: any[]
 }
 
-export default ({ t, n, x, a }: WuchaleComponentProps) =>
+export default ({ t = [], n, x, a }: WuchaleComponentProps) =>
     x.map((x, i) => {
         if (typeof x === 'string') {
             return x

--- a/packages/astro/src/transformer.test.ts
+++ b/packages/astro/src/transformer.test.ts
@@ -225,8 +225,8 @@ test('Nested and mixed', async t => {
                     x: _w_ctx_,
                     n: true,
                     a: [appName]
-            })}</i></b>]
-            })}]
+            })}</i>]
+            })}</b>]
         })}</p>
     `,
         ['Hello and <0>welcome to <0>the app {0}</0></0>!'],

--- a/packages/astro/src/transformer.test.ts
+++ b/packages/astro/src/transformer.test.ts
@@ -225,7 +225,8 @@ test('Nested and mixed', async t => {
                     x: _w_ctx_,
                     n: true,
                     a: [appName]
-            })}</i></b>]]
+            })}</i></b>]
+            })}]
         })}</p>
     `,
         ['Hello and <0>welcome to <0>the app {0}</0></0>!'],

--- a/packages/astro/src/transformer.ts
+++ b/packages/astro/src/transformer.ts
@@ -35,9 +35,6 @@ export function parseExpr(content: string): [Estree.Expression, Estree.Comment[]
     return [ExprParser.parseExpressionAt(content, 0, opts), comments]
 }
 
-const tagNodes = ['element', 'component', 'custom-element']
-const nodesWithChildren = [...tagNodes, 'fragment']
-
 const rtRenderFunc = '_w_Tx_'
 
 const u8decoder = new TextDecoder()
@@ -75,15 +72,11 @@ export class AstroTransformer extends Transformer {
 
     _saveCorrectedRanges(nodes: Node[], containerEnd: number) {
         for (const [i, child] of nodes.entries()) {
-            const isExpr = child.type === 'expression'
-            const isTag = tagNodes.includes(child.type)
-            if (!(isExpr || isTag)) {
+            if (child.type !== 'expression') {
                 continue
             }
             let start = this._byteOffsetToIndex(child.position?.start?.offset)
-            if (isExpr) {
-                start = this.content.indexOf('{', start)
-            }
+            start = this.content.indexOf('{', start)
             const nextChild = nodes[i + 1]
             let end: number = this._byteOffsetToIndex(child.position?.end?.offset)
             if (nextChild != null) {
@@ -92,8 +85,7 @@ export class AstroTransformer extends Transformer {
                     end = this.content.indexOf('{', end)
                 }
             } else {
-                const lookFor = isExpr ? '}' : '>'
-                end = this.content.lastIndexOf(lookFor, containerEnd) + lookFor.length
+                end = this.content.lastIndexOf('}', containerEnd) + 1
             }
             this.correctedExprRanges.set(child, { start, end })
         }
@@ -124,17 +116,17 @@ export class AstroTransformer extends Transformer {
             isExpression: node => node.type === 'expression',
             getTextContent: node => node.value,
             getCommentData: node => node.value.trim(),
-            canHaveChildren: node => nodesWithChildren.includes(node.type),
             visitFunc: this.visitAs.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
+                const vars = this.vars()
                 let begin = `{${rtRenderFunc}({\nx: `
                 if (inNested) {
-                    begin += `${this.vars().nestCtx},\nn: true`
+                    begin += `${vars.nestCtx},\nn: true`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
-                    begin += `${this.vars().rtCtx}(${index})`
+                    begin += `${vars.rtCtx}(${index})`
                 }
                 if (nestedRanges.length > 0) {
                     for (const [i, [childStart, _, haveCtx]] of nestedRanges.entries()) {
@@ -144,7 +136,7 @@ export class AstroTransformer extends Transformer {
                         } else {
                             toAppend = ', '
                         }
-                        this.mstr.appendRight(childStart, `${toAppend}${haveCtx ? this.vars().nestCtx : '()'} => `)
+                        this.mstr.appendRight(childStart, `${toAppend}${haveCtx ? vars.nestCtx : '()'} => `)
                     }
                     begin = `]`
                 }
@@ -184,7 +176,6 @@ export class AstroTransformer extends Transformer {
             }
             msgs.push(...this.visitAs(part))
             const { start, end } = this.getRange(part)
-            if (end === -1) console.log(part, node)
             expr += `"${' '.repeat(end - start)}"`
         }
         msgs.push(...this._parseAndVisitExpr(expr, start + 1))

--- a/packages/astro/src/transformer.ts
+++ b/packages/astro/src/transformer.ts
@@ -25,7 +25,7 @@ import type {
     TransformOutput,
 } from 'wuchale'
 import { getKey } from 'wuchale'
-import { MixedVisitor, nonWhitespaceText } from 'wuchale/adapter-utils'
+import { MixedVisitor } from 'wuchale/adapter-utils'
 import { parseScript, scriptParseOptionsWithComments, Transformer } from 'wuchale/adapter-vanilla'
 
 const ExprParser = Parser.extend(tsPlugin())
@@ -42,17 +42,15 @@ const rtRenderFunc = '_w_Tx_'
 
 const u8decoder = new TextDecoder()
 
-type MixedVisitorAstro = MixedVisitor<Node, object, TextNode, CommentNode, ExpressionNode>
+type MixedVisitorAstro = MixedVisitor<Node, TextNode, CommentNode, ExpressionNode>
 
 export class AstroTransformer extends Transformer {
     byteArray: Uint8Array
     // state
     currentElement?: string | undefined
-    inCompoundText: boolean = false
     frontMatterStart?: number
 
     mixedVisitor: MixedVisitorAstro
-    addCtx = {}
 
     // astro's compiler gives wrong offsets for expressions
     correctedExprRanges: WeakMap<Node | AttributeNode, { start: number; end: number }> = new WeakMap()
@@ -115,8 +113,10 @@ export class AstroTransformer extends Transformer {
 
     initMixedVisitor(): MixedVisitorAstro {
         return new MixedVisitor({
-            vars: this.vars.bind(this),
+            mstr: this.mstr,
+            index: this.index,
             content: this.content,
+            vars: this.vars.bind(this),
             getRange: this.getRange.bind(this),
             isText: node => node.type === 'text',
             isComment: node => node.type === 'comment',
@@ -125,12 +125,12 @@ export class AstroTransformer extends Transformer {
             getTextContent: node => node.value,
             getCommentData: node => node.value.trim(),
             canHaveChildren: node => nodesWithChildren.includes(node.type),
-            visitFunc: MixedVisitor.withCtxRestore(this, this.visitAs.bind(this)),
+            visitFunc: this.visitAs.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
-            wrapNested: (msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
+            wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
                 let begin = `{${rtRenderFunc}({\nx: `
-                if (this.inCompoundText) {
+                if (inNested) {
                     begin += `${this.vars().nestCtx},\nn: true`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
@@ -193,12 +193,8 @@ export class AstroTransformer extends Transformer {
 
     _visitChildren = (nodes: Node[]): Message[] =>
         this.mixedVisitor.visit({
-            mstr: this.mstr,
-            index: this.index,
-            addCtx: this.addCtx,
             children: nodes,
             commentDirectives: this.commentDirectives,
-            inCompoundText: this.inCompoundText,
             scope: 'markup',
             element: this.currentElement as string,
             useComponent: this.currentElement !== 'title',
@@ -264,20 +260,6 @@ export class AstroTransformer extends Transformer {
         return []
     }
 
-    visittext(node: TextNode): Message[] {
-        const [startWh, trimmed, endWh] = nonWhitespaceText(node.value)
-        const [pass, msgInfo] = this.checkHeuristic(trimmed, {
-            scope: 'markup',
-            element: this.currentElement,
-        })
-        if (!pass) {
-            return []
-        }
-        const { start, end } = this.getRange(node)
-        this.mstr.update(start + startWh, end - endWh, `{${this.literalRepl(msgInfo)}}`)
-        return [msgInfo]
-    }
-
     visitfrontmatter(node: FrontmatterNode): Message[] {
         const { start } = this.getRange(node)
         this.frontMatterStart = this.content.indexOf('---', start) + 3
@@ -288,7 +270,8 @@ export class AstroTransformer extends Transformer {
         // node.children can be undefined!
         const children = node.children ?? []
         this._saveCorrectedRanges(children, this.content.length)
-        return this._visitChildren(children)
+        const msgs = [...this._visitChildren(children), ...this.mixedVisitor.applyMod()]
+        return msgs
     }
 
     visitAs(node: Node | AttributeNode | Estree.AnyNode): Message[] {

--- a/packages/jsx/src/transformer.test.ts
+++ b/packages/jsx/src/transformer.test.ts
@@ -233,7 +233,7 @@ test('Nested and mixed', async (t: TestContext) => {
             function m() {
                 const _w_runtime_ = _w_load_();
                 return <>
-                    <p><W_tx_ t={[_w_ctx_ => <b key="_1"><W_tx_ t={[_w_ctx_ => <i key="_0"><W_tx_ x={_w_ctx_} n a={[appName]} /></i>]} x={_w_ctx_} n /></b>]} x={_w_runtime_.c(0)} /></p>
+                    <p><W_tx_ t={[_w_ctx_ => <b key="_0"><W_tx_ t={[_w_ctx_ => <i key="_1"><W_tx_ x={_w_ctx_} n a={[appName]} /></i>]} x={_w_ctx_} n /></b>]} x={_w_runtime_.c(0)} /></p>
                 </>
             }
     `,

--- a/packages/jsx/src/transformer.ts
+++ b/packages/jsx/src/transformer.ts
@@ -4,7 +4,7 @@ import { Parser } from 'acorn'
 import type * as JX from 'estree-jsx'
 import type { CodePattern, HeuristicFunc, Message, RuntimeConf, TransformCtx, TransformOutput } from 'wuchale'
 import { getKey } from 'wuchale'
-import { MixedVisitor, nonWhitespaceText } from 'wuchale/adapter-utils'
+import { MixedVisitor, type ModFunc } from 'wuchale/adapter-utils'
 import { parseScript, scriptParseOptionsWithComments, Transformer } from 'wuchale/adapter-vanilla'
 
 const JsxParser = Parser.extend(tsPlugin({ jsx: true }))
@@ -18,25 +18,16 @@ const nodesWithChildren = ['JSXElement']
 const rtComponent = 'W_tx_'
 
 type MixedNodesTypes = JX.JSXElement | JX.JSXFragment | JX.JSXText | JX.JSXExpressionContainer | JX.JSXSpreadChild
-type AddCtx = {
-    currentJsxKey?: number
-}
-type MixedVisitorJSX = MixedVisitor<
-    MixedNodesTypes,
-    AddCtx,
-    JX.JSXText,
-    JX.JSXExpressionContainer,
-    JX.JSXExpressionContainer
->
+
+type MixedVisitorJSX = MixedVisitor<MixedNodesTypes, JX.JSXText, JX.JSXExpressionContainer, JX.JSXExpressionContainer>
 
 export type JSXLib = 'default' | 'solidjs'
 
 export class JSXTransformer extends Transformer {
     // state
     currentElement?: string | undefined
-    inCompoundText: boolean = false
     lastVisitIsComment: boolean = false
-    addCtx: AddCtx = {}
+    currentJsxKey?: number
 
     mixedVisitor: MixedVisitorJSX
 
@@ -47,8 +38,10 @@ export class JSXTransformer extends Transformer {
 
     initMixedVisitor(): MixedVisitorJSX {
         return new MixedVisitor({
-            vars: this.vars.bind(this),
+            mstr: this.mstr,
+            index: this.index,
             content: this.content,
+            vars: this.vars.bind(this),
             getRange: node => ({
                 start: node.start,
                 end: node.end,
@@ -63,10 +56,10 @@ export class JSXTransformer extends Transformer {
             getTextContent: node => node.value,
             getCommentData: node => this.getMarkupCommentBody(node.expression as JX.JSXEmptyExpression),
             canHaveChildren: node => nodesWithChildren.includes(node.type),
-            visitFunc: MixedVisitor.withCtxRestore(this, this.visitJx.bind(this)),
+            visitFunc: this.visitJx.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
-            wrapNested: (msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
+            wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
                 let begin = `<${rtComponent}`
                 if (nestedRanges.length > 0) {
                     for (const [i, [childStart, _, haveCtx]] of nestedRanges.entries()) {
@@ -81,7 +74,7 @@ export class JSXTransformer extends Transformer {
                     begin = `]}`
                 }
                 begin += ' x='
-                if (this.inCompoundText) {
+                if (inNested) {
                     begin += `{${this.vars().nestCtx}} n`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
@@ -98,21 +91,21 @@ export class JSXTransformer extends Transformer {
         })
     }
 
-    visitChildrenJ(node: JX.JSXElement | JX.JSXFragment): Message[] {
+    visitChildrenJ(node: JX.JSXElement | JX.JSXFragment, addMod?: ModFunc): Message[] {
         const prevInsideProg = this.heuristciDetails.insideProgram
         this.heuristciDetails.insideProgram = false
-        const msg = this.mixedVisitor.visit({
-            mstr: this.mstr,
-            index: this.index,
-            addCtx: this.addCtx,
+        const msgs = this.mixedVisitor.visit({
             children: node.children,
             commentDirectives: this.commentDirectives,
-            inCompoundText: this.inCompoundText,
             scope: 'markup',
             element: this.currentElement as string,
+            addMod,
         })
+        if (prevInsideProg) {
+            msgs.push(...this.mixedVisitor.applyMod('markup'))
+        }
         this.heuristciDetails.insideProgram = prevInsideProg // restore
-        return msg
+        return msgs
     }
 
     visitNameJSXNamespacedName(node: JX.JSXNamespacedName): string {
@@ -134,38 +127,33 @@ export class JSXTransformer extends Transformer {
     visitJSXElement(node: JX.JSXElement): Message[] {
         const currentElement = this.currentElement
         this.currentElement = this.visitName(node.openingElement.name)
-        const msgs = this.visitChildrenJ(node)
+        let addMod: ModFunc | undefined
+        const key = node.openingElement.attributes.find(
+            attr => attr.type === 'JSXAttribute' && attr.name.name === 'key',
+        )
+        if (!key) {
+            addMod = nested => {
+                if (!nested || this.currentJsxKey == null) {
+                    return
+                }
+                this.mstr.appendLeft(node.openingElement.name.end, ` key="_${this.currentJsxKey}"`)
+                this.currentJsxKey++
+            }
+        }
+        const msgs = this.visitChildrenJ(node, addMod)
         for (const attr of node.openingElement.attributes) {
             msgs.push(...this.visitJx(attr))
-        }
-        if (this.inCompoundText && this.addCtx.currentJsxKey != null) {
-            const key = node.openingElement.attributes.find(
-                attr => attr.type === 'JSXAttribute' && attr.name.name === 'key',
-            )
-            if (!key) {
-                this.mstr.appendLeft(node.openingElement.name.end, ` key="_${this.addCtx.currentJsxKey}"`)
-                this.addCtx.currentJsxKey++
-            }
         }
         this.currentElement = currentElement
         return msgs
     }
 
-    visitJSXText(node: JX.JSXText): Message[] {
-        const [startWh, trimmed, endWh] = nonWhitespaceText(node.value)
-        const [pass, msgInfo] = this.checkHeuristic(trimmed, {
-            scope: 'markup',
-            element: this.currentElement,
-        })
-        if (!pass) {
-            return []
-        }
-        this.mstr.update(node.start + startWh, node.end - endWh, `{${this.literalRepl(msgInfo)}}`)
-        return [msgInfo]
-    }
-
     visitJSXFragment(node: JX.JSXFragment): Message[] {
-        return this.visitChildrenJ(node)
+        const currentElement = this.currentElement
+        this.currentElement = ''
+        const msgs = this.visitChildrenJ(node)
+        this.currentElement = currentElement
+        return msgs
     }
 
     getMarkupCommentBody(node: JX.JSXEmptyExpression): string {
@@ -235,7 +223,7 @@ export class JSXTransformer extends Transformer {
         )
         this.comments = comments
         if (lib === 'default') {
-            this.addCtx.currentJsxKey = 0
+            this.currentJsxKey = 0
         }
         const msgs = this.visitJx(ast)
         const header = [

--- a/packages/jsx/src/transformer.ts
+++ b/packages/jsx/src/transformer.ts
@@ -14,7 +14,6 @@ export function parseScriptJSX(content: string): [Estree.Program, Estree.Comment
     return [JsxParser.parse(content, opts), comments]
 }
 
-const nodesWithChildren = ['JSXElement']
 const rtComponent = 'W_tx_'
 
 type MixedNodesTypes = JX.JSXElement | JX.JSXFragment | JX.JSXText | JX.JSXExpressionContainer | JX.JSXSpreadChild
@@ -55,11 +54,11 @@ export class JSXTransformer extends Transformer {
             isExpression: node => node.type === 'JSXExpressionContainer',
             getTextContent: node => node.value,
             getCommentData: node => this.getMarkupCommentBody(node.expression as JX.JSXEmptyExpression),
-            canHaveChildren: node => nodesWithChildren.includes(node.type),
             visitFunc: this.visitJx.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
+                const vars = this.vars()
                 let begin = `<${rtComponent}`
                 if (nestedRanges.length > 0) {
                     for (const [i, [childStart, _, haveCtx]] of nestedRanges.entries()) {
@@ -69,16 +68,16 @@ export class JSXTransformer extends Transformer {
                         } else {
                             toAppend = ', '
                         }
-                        this.mstr.appendRight(childStart, `${toAppend}${haveCtx ? this.vars().nestCtx : '()'} => `)
+                        this.mstr.appendRight(childStart, `${toAppend}${haveCtx ? vars.nestCtx : '()'} => `)
                     }
                     begin = `]}`
                 }
                 begin += ' x='
                 if (inNested) {
-                    begin += `{${this.vars().nestCtx}} n`
+                    begin += `{${vars.nestCtx}} n`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
-                    begin += `{${this.vars().rtCtx}(${index})}`
+                    begin += `{${vars.rtCtx}(${index})}`
                 }
                 let end = ' />'
                 if (hasExprs) {

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -36,7 +36,9 @@ test('Simple text and props destruct', async t => {
         <script>
             let { label = 'Hello' } = $props()
         </script>
-        Hello
+        <div>
+            Hello
+        </div>
         `),
         svelte`
         <script>
@@ -45,7 +47,9 @@ test('Simple text and props destruct', async t => {
             const _w_runtime_ = $derived(_w_load_rx_());
             let { label = _w_runtime_(0) } = $props()
         </script>
-        {_w_runtime_(0)}
+        <div>
+            {_w_runtime_(0)}
+        </div>
     `,
         ['Hello', 'Hello'],
     )
@@ -229,27 +233,27 @@ test('URLs', async t => {
                 }
             })
         </script>
-        <a href={_w_localize_(_w_runtime_(3), _w_runtime_.l)}>{_w_runtime_(4)}</a>
-        <a href={_w_localize_(_w_runtime_(5), _w_runtime_.l)}>{_w_runtime_(4)}</a>
-        <a href={_w_localize_(_w_runtime_(6, [44]), _w_runtime_.l)}>{_w_runtime_(4)}</a>
-        <a href={_w_localize_(_w_runtime_(0, [44]), _w_runtime_.l)}>{_w_runtime_(4)}</a>
-        <a href="/notinpattern">{_w_runtime_(4)}</a>
-        <a href={_w_localize_(_w_runtime_(7), _w_runtime_.l)}>{_w_runtime_(4)}</a>
+        <a href={_w_localize_(_w_runtime_(3), _w_runtime_.l)}>{_w_runtime_(7)}</a>
+        <a href={_w_localize_(_w_runtime_(4), _w_runtime_.l)}>{_w_runtime_(7)}</a>
+        <a href={_w_localize_(_w_runtime_(5, [44]), _w_runtime_.l)}>{_w_runtime_(7)}</a>
+        <a href={_w_localize_(_w_runtime_(0, [44]), _w_runtime_.l)}>{_w_runtime_(7)}</a>
+        <a href="/notinpattern">{_w_runtime_(7)}</a>
+        <a href={_w_localize_(_w_runtime_(6), _w_runtime_.l)}>{_w_runtime_(7)}</a>
     `,
         [
             { msgStr: ['/translated/{0}'], type: 'url' },
             { msgStr: ['/translated/somewhere/{0}'], type: 'url' },
             { msgStr: ['/translated/propertyhref'], type: 'url' },
             { msgStr: ['/translated/hello'], type: 'url' },
-            'Hello',
             { msgStr: ['/translated/hello/there'], type: 'url' },
-            'Hello',
             { msgStr: ['/translated/very/deep/link/{0}'], type: 'url' },
-            'Hello',
             { msgStr: ['/translated/{0}'], type: 'url' },
-            'Hello',
-            'Hello',
             { msgStr: ['/'], type: 'url' },
+            'Hello',
+            'Hello',
+            'Hello',
+            'Hello',
+            'Hello',
             'Hello',
         ],
     )
@@ -322,10 +326,10 @@ test('Context', async t => {
         await getOutput(svelte`
             <p>{/* @wc-context: music */ 'String'}</p>
             <p>{/* @wc-context: programming */ 'String'}</p>
-            <!-- @wc-context: door -->
-            <p>Close</p>
             <!-- @wc-context: distance -->
             <p>Close</p>
+            <!-- @wc-context: door -->
+            Close
         `),
         svelte`
             <script>
@@ -335,12 +339,17 @@ test('Context', async t => {
             </script>
             <p>{/* @wc-context: music */ _w_runtime_(0)}</p>
             <p>{/* @wc-context: programming */ _w_runtime_(1)}</p>
-            <!-- @wc-context: door -->
-            <p>{_w_runtime_(2)}</p>
             <!-- @wc-context: distance -->
             <p>{_w_runtime_(3)}</p>
+            <!-- @wc-context: door -->
+            {_w_runtime_(2)}
     `,
-        ['String', 'String', 'Close', 'Close'],
+        [
+            { msgStr: ['String'], context: 'music' },
+            { msgStr: ['String'], context: 'programming' },
+            { msgStr: ['Close'], context: 'door' },
+            { msgStr: ['Close'], context: 'distance' },
+        ],
     )
 })
 
@@ -381,17 +390,17 @@ test('Nested and mixed with svelte:element', async t => {
             const _w_runtime_ = $derived(_w_load_rx_());
         </script>
         <p>
-            {#snippet _w_snippet_1(_w_ctx_)}
+            {#snippet _w_snippet_0(_w_ctx_)}
                 <svelte:element this="b">
-                    {#snippet _w_snippet_0(_w_ctx_)}
+                    {#snippet _w_snippet_1(_w_ctx_)}
                         <i>
                             <W_tx_ x={_w_ctx_} n a={[appName]} />
                         </i>
                     {/snippet}
-                    <W_tx_ t={[_w_snippet_0]} x={_w_ctx_} n />
+                    <W_tx_ t={[_w_snippet_1]} x={_w_ctx_} n />
                 </svelte:element>
             {/snippet}
-            <W_tx_ t={[_w_snippet_1]} x={_w_runtime_.c(0)} />
+            <W_tx_ t={[_w_snippet_0]} x={_w_runtime_.c(0)} />
         </p>
     `,
         ['Hello and <0>welcome to <0>the app {0}</0></0>!'],

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -407,6 +407,40 @@ test('Nested and mixed with svelte:element', async t => {
     )
 })
 
+test('Collapsing deep nested messages', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+            Hello
+            <a><b><i><Foo /></i></b><Bar /></a>
+            there
+            <a><b><i>user {user}</i></b></a>
+        `),
+        svelte`
+            <script>
+                import { _w_load_, _w_load_rx_ } from "./loader.js"
+                import W_tx_ from "@wuchale/svelte/runtime.svelte"
+                const _w_runtime_ = $derived(_w_load_rx_());
+            </script>
+            {#snippet _w_snippet_0()}
+                <a><b><i><Foo /></i></b><Bar /></a>
+            {/snippet}
+            {#snippet _w_snippet_1(_w_ctx_)}
+                <a><b><i>
+                    <W_tx_ x={_w_ctx_} n a={[user]} />
+                </i></b></a>
+            {/snippet}
+            <W_tx_ t={[_w_snippet_0, _w_snippet_1]} x={_w_runtime_.c(0)} />
+        `,
+        [
+            {
+                msgStr: ['Hello <0/> there <1>user {0}</1>'],
+                placeholders: [['1.0', 'user']],
+            },
+        ],
+    )
+})
+
 test('svelte:element uses static tag context', async t => {
     transformTest(
         t,

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -22,7 +22,6 @@ import { getKey } from 'wuchale'
 import { MixedVisitor, varNames } from 'wuchale/adapter-utils'
 import { parseScript, Transformer } from 'wuchale/adapter-vanilla'
 
-const nodesWithChildren = ['RegularElement', 'Component', 'SvelteElement']
 const noWrapTopCalls = ['$props', '$state', '$derived', '$effect']
 
 const rtComponent = 'W_tx_'
@@ -112,18 +111,18 @@ export class SvelteTransformer extends Transformer {
             isExpression: node => node.type === 'ExpressionTag',
             getTextContent: node => node.data,
             getCommentData: node => node.data.trim(),
-            canHaveChildren: node => nodesWithChildren.includes(node.type),
             visitFunc: this.visitSv.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
                 const snippets: string[] = []
+                const vars = this.vars()
                 // create and reference snippets
                 for (const [childStart, childEnd, haveCtx] of nestedRanges) {
                     const snippetName = `${snipPrefix}${this.currentSnippet}`
                     snippets.push(snippetName)
                     this.currentSnippet++
-                    const snippetBegin = `\n{#snippet ${snippetName}(${haveCtx ? this.vars().nestCtx : ''})}\n`
+                    const snippetBegin = `\n{#snippet ${snippetName}(${haveCtx ? vars.nestCtx : ''})}\n`
                     this.mstr.appendRight(childStart, snippetBegin)
                     this.mstr.prependLeft(childEnd, '\n{/snippet}\n')
                 }
@@ -133,10 +132,10 @@ export class SvelteTransformer extends Transformer {
                 }
                 begin += ' x='
                 if (inNested) {
-                    begin += `{${this.vars().nestCtx}} n`
+                    begin += `{${vars.nestCtx}} n`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
-                    begin += `{${this.vars().rtCtx}(${index})}`
+                    begin += `{${vars.rtCtx}(${index})}`
                 }
                 let end = ' />\n'
                 if (hasExprs) {

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -19,7 +19,7 @@ import type {
     TransformOutput,
 } from 'wuchale'
 import { getKey } from 'wuchale'
-import { MixedVisitor, nonWhitespaceText, varNames } from 'wuchale/adapter-utils'
+import { MixedVisitor, varNames } from 'wuchale/adapter-utils'
 import { parseScript, Transformer } from 'wuchale/adapter-vanilla'
 
 const nodesWithChildren = ['RegularElement', 'Component', 'SvelteElement']
@@ -31,10 +31,7 @@ const snipPrefix = '_w_snippet_'
 const rtModuleVar = `${varNames.rt}mod_`
 
 type MixedNodesTypes = AST.Text | AST.Tag | AST.ElementLike | AST.SvelteElement | AST.Block | AST.Comment
-type AddCtx = {
-    currentSnippet: number
-}
-type MixedVisitorSvelte = MixedVisitor<MixedNodesTypes, AddCtx, AST.Text, AST.Comment, AST.ExpressionTag>
+type MixedVisitorSvelte = MixedVisitor<MixedNodesTypes, AST.Text, AST.Comment, AST.ExpressionTag>
 
 // for use before actually parsing the code,
 // to remove the contents of e.g. <style lang="scss"> which can cause parse errors
@@ -51,8 +48,7 @@ export type RuntimeCtxSv = {
 export class SvelteTransformer extends Transformer {
     // state
     currentElement?: string | undefined
-    inCompoundText: boolean = false
-    addCtx: AddCtx = { currentSnippet: 0 }
+    currentSnippet = 0
     moduleExportExprs: AnyNode[] = [] // to choose which runtime var to use for snippets
 
     mixedVisitor: MixedVisitorSvelte
@@ -105,8 +101,10 @@ export class SvelteTransformer extends Transformer {
 
     initMixedVisitor(): MixedVisitorSvelte {
         return new MixedVisitor({
-            vars: this.vars.bind(this),
+            mstr: this.mstr,
+            index: this.index,
             content: this.content,
+            vars: this.vars.bind(this),
             getRange: node => ({ start: node.start, end: node.end }),
             isText: node => node.type === 'Text',
             isComment: node => node.type === 'Comment',
@@ -115,16 +113,16 @@ export class SvelteTransformer extends Transformer {
             getTextContent: node => node.data,
             getCommentData: node => node.data.trim(),
             canHaveChildren: node => nodesWithChildren.includes(node.type),
-            visitFunc: MixedVisitor.withCtxRestore(this, this.visitSv.bind(this)),
+            visitFunc: this.visitSv.bind(this),
             fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
-            wrapNested: (msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
+            wrapNested: (inNested, msgInfo, hasExprs, nestedRanges, lastChildEnd) => {
                 const snippets: string[] = []
                 // create and reference snippets
                 for (const [childStart, childEnd, haveCtx] of nestedRanges) {
-                    const snippetName = `${snipPrefix}${this.addCtx.currentSnippet}`
+                    const snippetName = `${snipPrefix}${this.currentSnippet}`
                     snippets.push(snippetName)
-                    this.addCtx.currentSnippet++
+                    this.currentSnippet++
                     const snippetBegin = `\n{#snippet ${snippetName}(${haveCtx ? this.vars().nestCtx : ''})}\n`
                     this.mstr.appendRight(childStart, snippetBegin)
                     this.mstr.prependLeft(childEnd, '\n{/snippet}\n')
@@ -134,7 +132,7 @@ export class SvelteTransformer extends Transformer {
                     begin += ` t={[${snippets.join(', ')}]}`
                 }
                 begin += ' x='
-                if (this.inCompoundText) {
+                if (inNested) {
                     begin += `{${this.vars().nestCtx}} n`
                 } else {
                     const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
@@ -153,12 +151,8 @@ export class SvelteTransformer extends Transformer {
 
     visitFragment(node: AST.Fragment): Message[] {
         return this.mixedVisitor.visit({
-            mstr: this.mstr,
-            index: this.index,
-            addCtx: this.addCtx,
             children: node.nodes,
             commentDirectives: this.commentDirectives,
-            inCompoundText: this.inCompoundText,
             scope: 'markup',
             element: this.currentElement as string,
             useComponent: this.currentElement !== 'title',
@@ -181,19 +175,6 @@ export class SvelteTransformer extends Transformer {
         return this.visitRegularElement(node)
     }
 
-    visitText(node: AST.Text): Message[] {
-        const [startWh, trimmed, endWh] = nonWhitespaceText(node.data)
-        const [pass, msgInfo] = this.checkHeuristic(trimmed, {
-            scope: 'markup',
-            element: this.currentElement,
-        })
-        if (!pass) {
-            return []
-        }
-        this.mstr.update(node.start + startWh, node.end - endWh, `{${this.literalRepl(msgInfo)}}`)
-        return [msgInfo]
-    }
-
     visitSpreadAttribute(node: AST.SpreadAttribute): Message[] {
         return this.visit(node.expression as AnyNode)
     }
@@ -209,17 +190,15 @@ export class SvelteTransformer extends Transformer {
             values = [node.value]
         }
         if (values.length > 1) {
-            return this.mixedVisitor.visit({
-                mstr: this.mstr,
-                index: this.index,
-                addCtx: this.addCtx,
+            const msgs = this.mixedVisitor.visit({
                 children: values,
                 commentDirectives: this.commentDirectives,
-                inCompoundText: false,
                 scope: 'attribute',
                 element: this.currentElement as string,
                 attribute: node.name,
             })
+            msgs.push(...this.mixedVisitor.applyMod('attribute'))
+            return msgs
         }
         const value = values[0]!
         const heuDetails: HeuristicDetailsBase = {
@@ -399,7 +378,7 @@ export class SvelteTransformer extends Transformer {
             this.commentDirectives = {} // reset
             msgs.push(...this.visitProgram(node.instance.content as Program))
         }
-        msgs.push(...this.visitFragment(node.fragment))
+        msgs.push(...this.visitFragment(node.fragment), ...this.mixedVisitor.applyMod())
         return msgs
     }
 

--- a/packages/wuchale/src/adapter-utils/index.ts
+++ b/packages/wuchale/src/adapter-utils/index.ts
@@ -1,4 +1,4 @@
-export { MixedVisitor } from './mixed-visitor.js'
+export { MixedVisitor, type ModFunc } from './mixed-visitor.js'
 
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -25,14 +25,6 @@ export function runtimeVars(wrapFunc: (expr: string) => string, base = varNames.
 }
 
 export type RuntimeVars = ReturnType<typeof runtimeVars>
-
-export function nonWhitespaceText(msgStr: string): [number, string, number] {
-    const trimmedS = msgStr.trimStart()
-    const startWh = msgStr.length - trimmedS.length
-    const trimmed = trimmedS.trimEnd()
-    const endWh = trimmedS.length - trimmed.length
-    return [startWh, trimmed, endWh]
-}
 
 export function loaderPathResolver(importMetaUrl: string, baseDir: string, ext: string) {
     const dir = dirname(fileURLToPath(importMetaUrl))

--- a/packages/wuchale/src/adapter-utils/mixed-visitor.ts
+++ b/packages/wuchale/src/adapter-utils/mixed-visitor.ts
@@ -1,58 +1,35 @@
 // Shared logic between adapters for handling nested / mixed elements within elements / fragments
 
-import MagicString from 'magic-string'
+import type MagicString from 'magic-string'
 import {
     getKey,
     type HeuristicDetails,
     type HeuristicDetailsBase,
     type HeuristicFunc,
-    IndexTracker,
+    type IndexTracker,
     type Message,
     newMessage,
 } from '../adapters.js'
 import {
     type CommentDirectives,
     commentPrefix,
-    nonWhitespaceText,
     type RuntimeVars,
     restoreCommentDirectives,
     updateCommentDirectives,
     varNames,
 } from './index.js'
 
-const noopIndex = new IndexTracker(true)
-
-const noopMstr = new Proxy(new MagicString(''), {
-    get: (target, p: keyof MagicString) => {
-        if (typeof target[p] === 'function') {
-            return () => {}
-        }
-        return target[p]
-    },
-})
-
 type NestedRanges = [number, number, boolean][]
 
-type VisitVolatileCtx<A> = {
+type WrapNestedArgs = [msgInfo: Message, hasExprs: boolean, nestedRanges: NestedRanges, lastChildEnd: number]
+
+export type ModFunc = (nested: boolean, siblings: number) => void
+
+type InitProps<MixNodeT, TxtT extends MixNodeT, ComT extends MixNodeT, ExprT extends MixNodeT> = {
     mstr: MagicString
     index: IndexTracker
-    inCompoundText: boolean
-    addCtx: A
-}
-
-type VisitNestedCtx<A> = Omit<VisitVolatileCtx<A>, 'inCompoundText'>
-
-type VisitFunc<MixNodeT, AddCtx> = (node: MixNodeT, ctx: VisitVolatileCtx<AddCtx>) => Message[]
-
-type InitProps<
-    MixNodeT,
-    AddCtx extends object,
-    TxtT extends MixNodeT,
-    ComT extends MixNodeT,
-    ExprT extends MixNodeT,
-> = {
-    vars: () => RuntimeVars
     content: string
+    vars: () => RuntimeVars
     getRange: (node: MixNodeT) => { start: number; end: number }
     isText: (node: MixNodeT) => node is TxtT
     isExpression: (node: MixNodeT) => node is ExprT
@@ -61,15 +38,46 @@ type InitProps<
     canHaveChildren: (node: MixNodeT) => boolean
     getTextContent: (node: TxtT) => string
     getCommentData: (node: ComT) => string
-    visitFunc: VisitFunc<MixNodeT, AddCtx>
+    visitFunc: (node: MixNodeT) => Message[]
     fullHeuristicDetails: (details: HeuristicDetailsBase) => HeuristicDetails
     checkHeuristic: HeuristicFunc
-    wrapNested: (msgInfo: Message, hasExprs: boolean, nestedRanges: NestedRanges, lastChildEnd: number) => void
+    wrapNested: (inNested: boolean, ...args: WrapNestedArgs) => void
 }
 
 export type MixedScope = 'markup' | 'attribute'
 
-type VisitProps<NodeT, AddCtx> = VisitVolatileCtx<AddCtx> & {
+type LevelMod = {
+    msg: Message | null
+    txts: [Message, () => void][]
+    unit: boolean
+    pending: boolean
+    building: boolean
+    siblings: number
+    funcs: ModFunc[]
+    children: LevelMod[]
+}
+
+const newMod = (building = false, unit = false): LevelMod => ({
+    msg: null,
+    txts: [],
+    building,
+    unit,
+    pending: true,
+    siblings: 0,
+    funcs: [],
+    children: [],
+})
+
+/** trims from end first */
+export function nonWhitespaceText(msgStr: string): [number, string, number] {
+    const trimmedE = msgStr.trimEnd()
+    const endWh = msgStr.length - trimmedE.length
+    const trimmed = trimmedE.trimStart()
+    const startWh = trimmedE.length - trimmed.length
+    return [startWh, trimmed, endWh]
+}
+
+type VisitProps<NodeT> = {
     children: NodeT[]
     commentDirectives: CommentDirectives
     scope: MixedScope
@@ -79,154 +87,217 @@ type VisitProps<NodeT, AddCtx> = VisitVolatileCtx<AddCtx> & {
      * set to true when variables can be objects that cannot be converted to strings like
      * e.g. components in jsx to prevent `[object Object]` being rendered. */
     useComponent?: boolean
+    /** additional modify func to call */
+    addMod?: ModFunc | undefined
 }
 
 export class MixedVisitor<
     MixNodeT extends object,
-    AddCtx extends object,
     TxtT extends MixNodeT,
     ComT extends MixNodeT,
     ExprT extends MixNodeT,
 > {
-    #props: InitProps<MixNodeT, AddCtx, TxtT, ComT, ExprT>
-    #scouted = new WeakMap<MixNodeT, [boolean | null, boolean | null]>()
+    #props: InitProps<MixNodeT, TxtT, ComT, ExprT>
+    #mod = { markup: newMod(), attribute: newMod() }
 
-    constructor(props: InitProps<MixNodeT, AddCtx, TxtT, ComT, ExprT>) {
+    constructor(props: InitProps<MixNodeT, TxtT, ComT, ExprT>) {
         this.#props = props
     }
 
-    separatelyVisitChildren = (props: VisitProps<MixNodeT, AddCtx>) => {
+    /** apply pending nested message edits */
+    #applyMod(mod: LevelMod, depth = 0) {
+        if (!mod.pending) {
+            return []
+        }
         const msgs: Message[] = []
-        if (props.scope !== 'markup') {
-            return msgs
+        const nested = depth > 0
+        let modify = nested
+        if (!nested) {
+            if (mod.msg) {
+                if (mod.unit) {
+                    mod.msg.type = 'message'
+                    modify = true
+                } else if (mod.building) {
+                    const heurMsgType = this.#props.checkHeuristic(mod.msg)
+                    if (heurMsgType) {
+                        mod.msg.type = heurMsgType
+                        modify = true
+                    } else {
+                        modify = false
+                    }
+                }
+                modify && msgs.push(mod.msg)
+            } else {
+                for (const [msg, func] of mod.txts) {
+                    const heurMsgType = this.#props.checkHeuristic(msg)
+                    if (!heurMsgType) {
+                        continue
+                    }
+                    msg.type = heurMsgType
+                    msgs.push(msg)
+                    func()
+                }
+            }
         }
-        const commentDirectivesOrig: CommentDirectives = { ...props.commentDirectives }
-        let lastVisitIsComment = false
-        for (const child of props.children) {
-            if (this.#props.isComment(child)) {
-                updateCommentDirectives(this.#props.getCommentData(child), props.commentDirectives)
-                lastVisitIsComment = true
-                continue
+        if (modify) {
+            for (const func of mod.funcs) {
+                func(nested, mod.siblings)
             }
-            if (this.#props.isText(child) && !this.#props.getTextContent(child).trim()) {
-                continue
-            }
-            if (props.commentDirectives.ignoreFile) {
-                break
-            }
-            if (props.commentDirectives.forceType !== false) {
-                msgs.push(
-                    ...this.#props.visitFunc(child, {
-                        mstr: props.mstr,
-                        index: props.index,
-                        addCtx: props.addCtx,
-                        inCompoundText: false,
-                    }),
-                )
-            }
-            if (!lastVisitIsComment) {
-                continue
-            }
-            restoreCommentDirectives(props.commentDirectives, commentDirectivesOrig)
-            lastVisitIsComment = false
         }
+        for (const childMod of mod.children) {
+            msgs.push(...this.#applyMod(childMod, depth + (modify ? 1 : 0)))
+        }
+        mod.pending = false
         return msgs
     }
 
-    visitNested(props: VisitProps<MixNodeT, AddCtx>, ctx: VisitNestedCtx<AddCtx>, asCompound: true): Message[]
-    visitNested(props: VisitProps<MixNodeT, AddCtx>, ctx: VisitNestedCtx<AddCtx>, asCompound: false): boolean
-    visitNested(props: VisitProps<MixNodeT, AddCtx>, ctx: VisitNestedCtx<AddCtx>, asCompound: boolean) {
-        let hasTextChild = false
-        let hasNonTextChild = false
+    applyMod(scope: MixedScope = 'markup') {
+        const mod = this.#mod[scope]
+        const msgs = this.#applyMod(mod)
+        this.#mod[scope] = newMod() // in addition to pending for when called for last cleanup
+        return msgs
+    }
+
+    getLastChildEnd(children: MixNodeT[]): number {
+        const lastChild = children.slice(-1)[0]!
+        const lastChildEnd = this.#props.getRange(lastChild).end
+        if (this.#props.isText(lastChild)) {
+            const [, , endWh] = nonWhitespaceText(this.#props.getTextContent(lastChild))
+            return lastChildEnd - endWh
+        }
+        return lastChildEnd
+    }
+
+    visit(props: VisitProps<MixNodeT>) {
+        if (props.children.length === 0) {
+            return []
+        }
         let hasCommentDirectives = false
-        let hasTextDescendants = false
         let msgStr = ''
         let iArg = 0
         let iTag = 0
-        const lastChildEnd = this.#props.getRange(props.children.slice(-1)[0]!).end
+        const commentDirectivesOrig: CommentDirectives = { ...props.commentDirectives }
+        let lastVisitIsComment = false
+        const lastChildEnd = this.getLastChildEnd(props.children)
         const childrenNestedRanges: NestedRanges = []
         const msgs: Message[] = []
         const placeholders: [string, string][] = []
+        const vars = this.#props.vars()
+        const alreadyInsideUnit = props.commentDirectives.unit ?? false
+        const mod = this.#mod[props.scope]
+        mod.siblings = props.children.length
+        mod.building ||=
+            alreadyInsideUnit ||
+            props.children.find(c => this.#props.isText(c) && this.#props.getTextContent(c).trim()) != null
+        if (props.addMod) {
+            mod.funcs.push(props.addMod)
+        }
         for (const child of props.children) {
             if (this.#props.isComment(child)) {
-                if (this.#props.getCommentData(child).trim().startsWith(commentPrefix)) {
+                const data = this.#props.getCommentData(child)
+                if (data.trim().startsWith(commentPrefix)) {
+                    updateCommentDirectives(data, props.commentDirectives)
                     hasCommentDirectives = true
                 }
+                lastVisitIsComment = true
                 continue
+            }
+            if (props.commentDirectives.ignoreFile) {
+                return []
             }
             const chRange = this.#props.getRange(child)
             if (this.#props.isText(child)) {
                 const [startWh, trimmed, endWh] = nonWhitespaceText(this.#props.getTextContent(child))
-                const msgInfo = newMessage({
-                    msgStr: [trimmed],
-                    details: this.#props.fullHeuristicDetails({ scope: props.scope }),
-                    context: props.commentDirectives.context,
-                })
-                if (startWh && !msgStr.endsWith(' ')) {
+                if ((startWh || trimmed === '') && !msgStr.endsWith(' ')) {
                     msgStr += ' '
                 }
                 if (!trimmed) {
                     // whitespace
                     continue
                 }
-                hasTextChild = true
-                msgStr += msgInfo.msgStr
-                if (endWh) {
-                    msgStr += ' '
+                if (props.commentDirectives.forceType !== false) {
+                    msgStr += trimmed
+                    if (endWh) {
+                        msgStr += ' '
+                    }
+                    let start = chRange.start
+                    let end = chRange.end
+                    const msg = newMessage({
+                        msgStr: [trimmed],
+                        details: this.#props.fullHeuristicDetails({
+                            scope: props.scope,
+                            element: props.element,
+                            attribute: props.attribute,
+                        }),
+                        context: props.commentDirectives.context,
+                    })
+                    mod.txts.push([
+                        msg,
+                        () => {
+                            const index = this.#props.index.get(getKey(msg.msgStr, msg.context))
+                            this.#props.mstr.update(start + startWh, end - endWh, `{${vars.rtTrans}(${index})}`)
+                        },
+                    ])
+                    mod.funcs.push((nested, siblings) => {
+                        if (!nested && siblings === 1) {
+                            start += startWh
+                            end -= endWh
+                        }
+                        this.#props.mstr.remove(start, end)
+                    })
                 }
-                ctx.mstr.remove(chRange.start, chRange.end)
-                continue
-            }
-            if (this.#props.leaveInPlace(child)) {
-                msgs.push(
-                    ...this.#props.visitFunc(child, { ...ctx, inCompoundText: this.#props.canHaveChildren(child) }),
-                )
-                continue
-            }
-            hasNonTextChild = true
-            if (this.#props.isExpression(child)) {
-                msgs.push(...this.#props.visitFunc(child, { ...ctx, inCompoundText: props.inCompoundText }))
-                msgStr += `{${iArg}}`
-                placeholders.push([iArg.toString(), this.#props.content.slice(chRange.start + 1, chRange.end - 1)])
-                let moveStart = chRange.start
-                if (iArg > 0) {
-                    ctx.mstr.update(chRange.start, chRange.start + 1, ', ')
-                } else {
-                    moveStart++
-                    ctx.mstr.remove(chRange.start, chRange.start + 1)
+            } else if (props.commentDirectives.forceType !== false) {
+                if (this.#props.leaveInPlace(child)) {
+                    msgs.push(...this.#props.visitFunc(child))
+                    continue
                 }
-                ctx.mstr.move(moveStart, chRange.end - 1, lastChildEnd)
-                ctx.mstr.remove(chRange.end - 1, chRange.end)
-                iArg++
-                continue
-            }
-            // elements, components and other things as well
-            const canHaveChildren = this.#props.canHaveChildren(child)
-            const childMsgs = this.#props.visitFunc(child, { ...ctx, inCompoundText: asCompound })
-            let nestedNeedsCtx = false
-            let chTxt = ''
-            for (const msgInfo of childMsgs) {
-                if (canHaveChildren && msgInfo.details.scope === props.scope) {
-                    chTxt += msgInfo.msgStr[0]
-                    for (const [num, cont] of msgInfo.placeholders) {
+                if (this.#props.isExpression(child)) {
+                    msgs.push(...this.#props.visitFunc(child))
+                    msgStr += `{${iArg}}`
+                    const start = chRange.start + 1
+                    const end = chRange.end - 1
+                    placeholders.push([iArg.toString(), this.#props.content.slice(start, end)])
+                    const firstOne = iArg === 0
+                    mod.funcs.push(() => {
+                        let moveStart = chRange.start
+                        if (firstOne) {
+                            moveStart++
+                            this.#props.mstr.remove(chRange.start, start)
+                        } else {
+                            this.#props.mstr.update(chRange.start, start, ', ')
+                        }
+                        this.#props.mstr.move(moveStart, end, lastChildEnd)
+                        this.#props.mstr.remove(end, chRange.end)
+                    })
+                    iArg++
+                    continue
+                }
+                // elements, components and other things as well
+                const childMod: LevelMod = newMod(mod.building, !alreadyInsideUnit && props.commentDirectives.unit)
+                this.#mod[props.scope] = childMod
+                const childMsgs = this.#props.visitFunc(child)
+                this.#mod[props.scope] = mod
+                mod.children.push(childMod)
+                msgs.push(...childMsgs)
+                let nestedNeedsCtx = false
+                let chTxt = `<${iTag}/>`
+                const canHaveChildren = this.#props.canHaveChildren(child)
+                if (canHaveChildren && childMod.msg) {
+                    chTxt = `<${iTag}>${childMod.msg.msgStr[0]!}</${iTag}>`
+                    for (const [num, cont] of childMod.msg.placeholders) {
                         placeholders.push([`${iTag}.${num}`, cont])
                     }
-                    hasTextDescendants = true
                     nestedNeedsCtx = true
-                } else {
-                    // attributes, blocks
-                    msgs.push(msgInfo)
                 }
+                childrenNestedRanges.push([chRange.start, chRange.end, nestedNeedsCtx])
+                msgStr += chTxt
+                iTag++
             }
-            childrenNestedRanges.push([chRange.start, chRange.end, nestedNeedsCtx])
-            if (canHaveChildren && chTxt) {
-                chTxt = `<${iTag}>${chTxt}</${iTag}>`
-            } else {
-                // childless elements and everything else
-                chTxt = `<${iTag}/>`
+            if (!lastVisitIsComment) {
+                continue
             }
-            iTag++
-            msgStr += chTxt
+            restoreCommentDirectives(props.commentDirectives, commentDirectivesOrig)
+            lastVisitIsComment = false
         }
         const msgInfo = newMessage({
             msgStr: [msgStr.trim()],
@@ -238,90 +309,48 @@ export class MixedVisitor<
             context: props.commentDirectives.context,
             placeholders,
         })
-        const heurMsgType = this.#props.checkHeuristic(msgInfo)
-        msgInfo.type = heurMsgType || 'message'
-        const canBeCompound =
-            props.inCompoundText ||
-            props.commentDirectives.unit ||
-            (hasTextChild && hasNonTextChild && !hasCommentDirectives)
-        const allChecksPassed = props.commentDirectives.unit || (canBeCompound && heurMsgType)
-        if (!asCompound) {
-            return allChecksPassed
+        if (!hasCommentDirectives) {
+            // can be taken together
+            mod.msg = msgInfo
+            mod.txts = []
         }
-        if (!allChecksPassed) {
-            return msgs
-        }
-        if (hasTextChild || hasTextDescendants) {
-            msgs.push(msgInfo)
-        } else {
-            return msgs
-        }
-        if (((props.useComponent ?? true) && props.scope === 'markup' && iArg > 0) || childrenNestedRanges.length > 0) {
-            this.#props.wrapNested(msgInfo, iArg > 0, childrenNestedRanges, lastChildEnd)
-            return msgs
-        }
-        // no need for component use
-        let begin = '{'
-        let end = ')}'
-        if (props.inCompoundText) {
-            begin += `${this.#props.vars().rtTransCtx}(${this.#props.vars().nestCtx}`
-        } else {
-            if (msgInfo.type === 'url') {
-                begin += `${varNames.urlLocalize}(`
-                end = `), ${this.#props.vars().rtLocale}${end}`
+        mod.funcs.push(nested => {
+            if (
+                ((props.useComponent ?? true) && props.scope === 'markup' && iArg > 0) ||
+                childrenNestedRanges.length > 0
+            ) {
+                this.#props.wrapNested(nested, msgInfo, iArg > 0, childrenNestedRanges, lastChildEnd)
+                return
             }
-            begin += `${this.#props.vars().rtTrans}(${props.index.get(getKey(msgInfo.msgStr, msgInfo.context))}`
+            // no need for component use
+            let begin = '{'
+            let end = ')}'
+            if (nested) {
+                begin += `${vars.rtTransCtx}(${vars.nestCtx}`
+            } else {
+                if (msgInfo.type === 'url') {
+                    begin += `${varNames.urlLocalize}(`
+                    end = `), ${vars.rtLocale}${end}`
+                }
+                const index = this.#props.index.get(getKey(msgInfo.msgStr, msgInfo.context))
+                begin += `${vars.rtTrans}(${index}`
+            }
+            if (iArg > 0) {
+                begin += ', ['
+                end = `]${end}`
+            }
+            if (props.scope === 'attribute' && `'"`.includes(this.#props.content[lastChildEnd]!)) {
+                const firstChild = props.children[0]!
+                const { start } = this.#props.getRange(firstChild)
+                this.#props.mstr.remove(start - 1, start)
+                this.#props.mstr.remove(lastChildEnd, lastChildEnd + 1)
+            }
+            this.#props.mstr.appendLeft(lastChildEnd, begin)
+            this.#props.mstr.appendRight(lastChildEnd, end)
+        })
+        if (mod.unit || !mod.building || hasCommentDirectives) {
+            msgs.push(...this.applyMod(props.scope))
         }
-        if (iArg > 0) {
-            begin += ', ['
-            end = `]${end}`
-        }
-        if (props.scope === 'attribute' && `'"`.includes(this.#props.content[lastChildEnd]!)) {
-            const firstChild = props.children[0]!
-            const { start } = this.#props.getRange(firstChild)
-            ctx.mstr.remove(start - 1, start)
-            ctx.mstr.remove(lastChildEnd, lastChildEnd + 1)
-        }
-        ctx.mstr.appendLeft(lastChildEnd, begin)
-        ctx.mstr.appendRight(lastChildEnd, end)
         return msgs
-    }
-
-    visit = (props: VisitProps<MixNodeT, AddCtx>): Message[] => {
-        if (props.children.length === 0) {
-            return []
-        }
-        const scouKey = props.children[0]!
-        const scoutedBoth = this.#scouted.get(scouKey) ?? [null, null]
-        const scouKeyI = props.commentDirectives.unit ? 1 : 0
-        let scouted = scoutedBoth[scouKeyI]
-        if (scouted == null) {
-            scouted = this.visitNested(props, { mstr: noopMstr, index: noopIndex, addCtx: { ...props.addCtx } }, false)
-            scoutedBoth[scouKeyI] = scouted
-            this.#scouted.set(scouKey, scoutedBoth)
-        }
-        if (!scouted) {
-            return this.separatelyVisitChildren(props)
-        }
-        return this.visitNested(props, { mstr: props.mstr, index: props.index, addCtx: props.addCtx }, true) // really modify
-    }
-
-    static withCtxRestore<MixNodeT, AddCtx>(
-        transformer: VisitVolatileCtx<AddCtx>,
-        visitChild: (child: MixNodeT) => Message[],
-    ): VisitFunc<MixNodeT, AddCtx> {
-        return (child, ctx) => {
-            const prevCtx: VisitVolatileCtx<AddCtx> = {
-                inCompoundText: transformer.inCompoundText,
-                mstr: transformer.mstr,
-                index: transformer.index,
-                addCtx: transformer.addCtx,
-            }
-            Object.assign(transformer, ctx)
-            const msgs = visitChild(child)
-            // restore
-            Object.assign(transformer, prevCtx)
-            return msgs
-        }
     }
 }

--- a/packages/wuchale/src/adapter-utils/mixed-visitor.ts
+++ b/packages/wuchale/src/adapter-utils/mixed-visitor.ts
@@ -21,10 +21,6 @@ import {
 
 type NestedRanges = [number, number, boolean][]
 
-type WrapNestedArgs = [msgInfo: Message, hasExprs: boolean, nestedRanges: NestedRanges, lastChildEnd: number]
-
-export type ModFunc = (nested: boolean, siblings: number) => void
-
 type InitProps<MixNodeT, TxtT extends MixNodeT, ComT extends MixNodeT, ExprT extends MixNodeT> = {
     mstr: MagicString
     index: IndexTracker
@@ -35,41 +31,48 @@ type InitProps<MixNodeT, TxtT extends MixNodeT, ComT extends MixNodeT, ExprT ext
     isExpression: (node: MixNodeT) => node is ExprT
     isComment: (node: MixNodeT) => node is ComT
     leaveInPlace: (node: MixNodeT) => boolean
-    canHaveChildren: (node: MixNodeT) => boolean
     getTextContent: (node: TxtT) => string
     getCommentData: (node: ComT) => string
     visitFunc: (node: MixNodeT) => Message[]
     fullHeuristicDetails: (details: HeuristicDetailsBase) => HeuristicDetails
     checkHeuristic: HeuristicFunc
-    wrapNested: (inNested: boolean, ...args: WrapNestedArgs) => void
+    wrapNested: (
+        inNested: boolean,
+        msgInfo: Message,
+        hasExprs: boolean,
+        nestedRanges: NestedRanges,
+        lastChildEnd: number,
+    ) => void
 }
 
 export type MixedScope = 'markup' | 'attribute'
 
+export type ModFunc = (nested: boolean) => void
+
 type LevelMod = {
     msg: Message | null
     txts: [Message, () => void][]
+    hasTxtDesc: boolean
     unit: boolean
     pending: boolean
     building: boolean
-    siblings: number
     funcs: ModFunc[]
     children: LevelMod[]
 }
 
 const newMod = (building = false, unit = false): LevelMod => ({
     msg: null,
+    hasTxtDesc: false,
     txts: [],
     building,
     unit,
     pending: true,
-    siblings: 0,
     funcs: [],
     children: [],
 })
 
 /** trims from end first */
-export function nonWhitespaceText(msgStr: string): [number, string, number] {
+function nonWhitespaceText(msgStr: string): [number, string, number] {
     const trimmedE = msgStr.trimEnd()
     const endWh = msgStr.length - trimmedE.length
     const trimmed = trimmedE.trimStart()
@@ -141,7 +144,7 @@ export class MixedVisitor<
         }
         if (modify) {
             for (const func of mod.funcs) {
-                func(nested, mod.siblings)
+                func(nested)
             }
         }
         for (const childMod of mod.children) {
@@ -158,7 +161,7 @@ export class MixedVisitor<
         return msgs
     }
 
-    getLastChildEnd(children: MixNodeT[]): number {
+    #getLastChildEnd(children: MixNodeT[]): number {
         const lastChild = children.slice(-1)[0]!
         const lastChildEnd = this.#props.getRange(lastChild).end
         if (this.#props.isText(lastChild)) {
@@ -178,14 +181,13 @@ export class MixedVisitor<
         let iTag = 0
         const commentDirectivesOrig: CommentDirectives = { ...props.commentDirectives }
         let lastVisitIsComment = false
-        const lastChildEnd = this.getLastChildEnd(props.children)
+        const lastChildEnd = this.#getLastChildEnd(props.children)
         const childrenNestedRanges: NestedRanges = []
         const msgs: Message[] = []
         const placeholders: [string, string][] = []
         const vars = this.#props.vars()
         const alreadyInsideUnit = props.commentDirectives.unit ?? false
         const mod = this.#mod[props.scope]
-        mod.siblings = props.children.length
         mod.building ||=
             alreadyInsideUnit ||
             props.children.find(c => this.#props.isText(c) && this.#props.getTextContent(c).trim()) != null
@@ -216,6 +218,7 @@ export class MixedVisitor<
                     continue
                 }
                 if (props.commentDirectives.forceType !== false) {
+                    mod.hasTxtDesc = true
                     msgStr += trimmed
                     if (endWh) {
                         msgStr += ' '
@@ -238,8 +241,8 @@ export class MixedVisitor<
                             this.#props.mstr.update(start + startWh, end - endWh, `{${vars.rtTrans}(${index})}`)
                         },
                     ])
-                    mod.funcs.push((nested, siblings) => {
-                        if (!nested && siblings === 1) {
+                    mod.funcs.push(nested => {
+                        if (!nested && props.children.length === 1) {
                             start += startWh
                             end -= endWh
                         }
@@ -273,23 +276,30 @@ export class MixedVisitor<
                     continue
                 }
                 // elements, components and other things as well
-                const childMod: LevelMod = newMod(mod.building, !alreadyInsideUnit && props.commentDirectives.unit)
+                const childMod = newMod(mod.building, !alreadyInsideUnit && props.commentDirectives.unit)
                 this.#mod[props.scope] = childMod
                 const childMsgs = this.#props.visitFunc(child)
                 this.#mod[props.scope] = mod
                 mod.children.push(childMod)
+                if (childMod.hasTxtDesc) {
+                    mod.hasTxtDesc = true
+                }
                 msgs.push(...childMsgs)
                 let nestedNeedsCtx = false
                 let chTxt = `<${iTag}/>`
-                const canHaveChildren = this.#props.canHaveChildren(child)
-                if (canHaveChildren && childMod.msg) {
-                    chTxt = `<${iTag}>${childMod.msg.msgStr[0]!}</${iTag}>`
-                    for (const [num, cont] of childMod.msg.placeholders) {
-                        placeholders.push([`${iTag}.${num}`, cont])
+                if (childMod.msg) {
+                    if (props.children.length === 1) {
+                        chTxt = childMod.msg.msgStr[0]!
+                        placeholders.push(...childMod.msg.placeholders)
+                    } else if (childMod.hasTxtDesc) {
+                        chTxt = `<${iTag}>${childMod.msg.msgStr[0]!}</${iTag}>`
+                        for (const [num, cont] of childMod.msg.placeholders) {
+                            placeholders.push([`${iTag}.${num}`, cont])
+                        }
+                        nestedNeedsCtx = true
                     }
-                    nestedNeedsCtx = true
+                    childrenNestedRanges.push([chRange.start, chRange.end, nestedNeedsCtx])
                 }
-                childrenNestedRanges.push([chRange.start, chRange.end, nestedNeedsCtx])
                 msgStr += chTxt
                 iTag++
             }
@@ -315,11 +325,16 @@ export class MixedVisitor<
             mod.txts = []
         }
         mod.funcs.push(nested => {
+            if (!mod.hasTxtDesc) {
+                return
+            }
             if (
                 ((props.useComponent ?? true) && props.scope === 'markup' && iArg > 0) ||
                 childrenNestedRanges.length > 0
             ) {
-                this.#props.wrapNested(nested, msgInfo, iArg > 0, childrenNestedRanges, lastChildEnd)
+                if (props.children.length > 1) {
+                    this.#props.wrapNested(nested, msgInfo, iArg > 0, childrenNestedRanges, lastChildEnd)
+                }
                 return
             }
             // no need for component use

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -184,7 +184,7 @@ export class Transformer extends InertVisitors {
             // nothing to ask
             return false
         }
-        if (this.commentDirectives.forceType === false) {
+        if (this.commentDirectives.forceType === false || !this.index.has(getKey(msg.msgStr, msg.context))) {
             return false
         }
         const heuRes = this.heuristic(msg) ?? defaultHeuristicFuncOnly(msg) ?? 'message'
@@ -206,7 +206,7 @@ export class Transformer extends InertVisitors {
         })
         const heuRes = this.getHeuristicMessageType(msg)
         // not allowed here, or msg is new but new msgs are not allowed
-        if (!heuRes || !this.index.has(getKey(msg.msgStr, msg.context))) {
+        if (!heuRes) {
             return [false, null]
         }
         msg.type = heuRes
@@ -214,11 +214,13 @@ export class Transformer extends InertVisitors {
     }
 
     literalRepl(msgInfo: Message) {
-        const repl = `${this.vars().rtTrans}(${this.index.get(getKey(msgInfo.msgStr, msgInfo.context))})`
+        const vars = this.vars()
+        const indexKey = getKey(msgInfo.msgStr, msgInfo.context)
+        const repl = `${vars.rtTrans}(${this.index.get(indexKey)})`
         if (msgInfo.type !== 'url') {
             return repl
         }
-        return `${varNames.urlLocalize}(${repl}, ${this.vars().rtLocale})`
+        return `${varNames.urlLocalize}(${repl}, ${vars.rtLocale})`
     }
 
     visitLiteral(node: Estree.Literal, heuristicDetailsBase?: HeuristicDetailsBase): Message[] {

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -90,7 +90,11 @@ export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
                 }
             }
         }
-        const msgStr = msg.msgStr.join('\n')
+        let msgStr = msg.msgStr.join('\n')
+        if (msg.details.scope === 'markup') {
+            // only check the top level for letters
+            msgStr = msgStr.replaceAll(/<\d+\/>/g, '#').replaceAll(/<\d+>.+<\/\d+>/g, '#')
+        }
         const looksLikeUrlPath = msgStr.startsWith('/') && !msgStr.includes(' ')
         if (looksLikeUrlPath && (msg.details.scope === 'script' || msg.details.scope === 'attribute')) {
             if (msg.details.call) {


### PR DESCRIPTION
Previously the way the AST was traversed is parent-to-child with immediate modification, but that makes it impossible to guarantee that the text checked at the heuristic, (or more importantly whether the message already exists when `dev` is `read`) is the same as the stored one, because the child nodes are not visited yet at the time the parent is visited but after they are visited all edits were already applied with no way to revert them. And for that reason, the message texts checked were provisional, with `#` as a placeholder for children nodes.

To have that guarantee, the latest version started guaranteeing that the messages checked at the heuristics are the same as those stored in the catalogs. Implementation wise, it started visiting the AST tree twice per level, and that resulted in around 2^depth visits, and unnecessarily extended build times (#391). The reason is that the inner text fragments need to know whether they are inside a valid compound message like `Hello <i>there</i>` and depending on that they are transformed differently. And that is passed down from the parent, necessitating the two-pass approach to have the aforementioned guarantee. To mitigate the problem, a caching layer was introduced in the latest patch version, but the decision depends on multiple factors and it has shown to cause some problems.

This PR solves that by accumulating the edits as functions in an equivalent tree bottom-up, and does the check and edit top-bottom, discarding the prospective edits of the rejected messages after checking with the actual stored message texts. This also allowed an improvement where unnecessary nesting can be collapsed:

```svelte
Hello <a><b><c><d>user {user}</d></c></b></a>
```

is extracted as `Hello <0>user {0}</0>` because the nesting is irrelevant to translation, and the source (e.g. Svelte) is transformed into a compatible simpler structure that only needs one snippet:

```svelte
{#snippet _w_snippet_0(_w_ctx_)}
<a><b><c><d>
<W_tx_ x={_w_ctx_} n a={[user]} />
</d></c></b></a>
{/snippet}

<W_tx_ t={[_w_snippet_0]} x={_w_runtime_.c(0)} />
```
