### PR TITLE
Redesign extraction context management

### DIFF
--- a/.changeset/strong-chefs-raise.md
+++ b/.changeset/strong-chefs-raise.md
@@ -1,0 +1,28 @@
+---
+"wuchale": minor
+"@wuchale/svelte": minor
+"@wuchale/astro": minor
+"@wuchale/jsx": minor
+---
+
+!Replace single details object with an array of scope objects and separate filename for heuristic
+
+The heuristic function now gets called with two arguments: the extracted `Text` object, and the filename as a `string` argument. The `Text` object now has:
+
+- `.body: string[]` instead of `Message.msgStr`
+- `.path: Scope[]` instead of `Message.details` - this is an array of different small `Scope` objects that better conveys nesting information.
+- The rest of the properties are the same as `Message`
+
+Therefore if you implement a custom heuristic function you should for example:
+
+```diff
+-heuristic: (msg) => {
++heuristic: (text, file) => {
+-    if (msg.details.element || msg.details.file.endsWith('.foo')) {
++    if (text.path.some(s => s.type === 'element') || file.endsWith('.foo')) {
+         return false
+     }
+ }
+```
+
+The scope array is now used to ignore whole sub-trees of ignored elements even if they contain non-ignored elements.

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -8,7 +8,7 @@ import type {
     RuntimeConf,
 } from 'wuchale'
 import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
-import { loaderPathResolver } from 'wuchale/adapter-utils'
+import { getFuncNameNested, loaderPathResolver } from 'wuchale/adapter-utils'
 import { pluralPattern } from 'wuchale/adapter-vanilla'
 import { AstroTransformer } from './transformer.js'
 
@@ -43,7 +43,11 @@ export type AstroArgs = Omit<AdapterArgs<LoadersAvailable>, 'loading' | 'runtime
 
 export const defaultRuntime: RuntimeConf = {
     // Astro is SSR-only, so we use non-reactive runtime by default
-    initReactive: ({ funcName, nested }) => (funcName == null || !nested ? false : null), // Only init in top-level and top-level functions
+    initReactive: path => {
+        const [funcName, nested] = getFuncNameNested(path)
+        // Only init in top-level and top-level functions
+        return funcName == null || !nested ? false : null
+    },
     // Astro is SSR - always use non-reactive
     useReactive: () => false,
     reactive: {

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -14,15 +14,20 @@ import { AstroTransformer } from './transformer.js'
 
 export function createAstroHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
     const defaultHeuristic = createHeuristic(opts)
-    return msg => {
-        const defRes = defaultHeuristic(msg)
+    return (txt, file) => {
+        const defRes = defaultHeuristic(txt, file)
         if (!defRes) {
             return false
         }
-        if (msg.details.scope !== 'script') {
+        const scopeType = txt.path.at(-1)?.type
+        if (scopeType === 'attribute' || scopeType === 'element') {
             return defRes
         }
-        if (msg.details.call?.startsWith('Astro.') || (msg.details.funcName == null && msg.details.exported)) {
+        if (txt.path.some(s => s.type === 'call' && s.name.startsWith('Astro.'))) {
+            return false
+        }
+        const iExport = txt.path.findIndex(s => s.type === 'export')
+        if (iExport !== -1 && !txt.path.slice(iExport).some(s => s.type === 'function' || s.type === 'funcexpr')) {
             return false
         }
         return defRes

--- a/packages/astro/src/transformer.test.ts
+++ b/packages/astro/src/transformer.test.ts
@@ -200,7 +200,7 @@ test('Plural', async t => {
             ---
             <p>{plural(items, _w_runtime_.p(0), _w_runtime_._.p)}</p>
     `,
-        [{ msgStr: ['One item', '# items'] }],
+        [{ body: ['One item', '# items'] }],
     )
 })
 

--- a/packages/astro/src/transformer.ts
+++ b/packages/astro/src/transformer.ts
@@ -15,15 +15,7 @@ import type {
 import { tsPlugin } from '@sveltejs/acorn-typescript'
 import type * as Estree from 'acorn'
 import { Parser } from 'acorn'
-import type {
-    CodePattern,
-    HeuristicDetailsBase,
-    HeuristicFunc,
-    Message,
-    RuntimeConf,
-    TransformCtx,
-    TransformOutput,
-} from 'wuchale'
+import type { CodePattern, HeuristicFunc, RuntimeConf, Text, TransformCtx, TransformOutput } from 'wuchale'
 import { MixedVisitor } from 'wuchale/adapter-utils'
 import { parseScript, scriptParseOptionsWithComments, Transformer } from 'wuchale/adapter-vanilla'
 
@@ -42,8 +34,6 @@ type MixedVisitorAstro = MixedVisitor<Node, TextNode, CommentNode, ExpressionNod
 
 export class AstroTransformer extends Transformer {
     byteArray: Uint8Array
-    // state
-    currentElement?: string | undefined
     frontMatterStart?: number
 
     mixedVisitor: MixedVisitorAstro
@@ -56,7 +46,6 @@ export class AstroTransformer extends Transformer {
         ctx.content = ctx.content.trim()
         super(ctx, heuristic, patterns, rtConf)
         this.byteArray = new Uint8Array(Buffer.from(this.content))
-        this.heuristciDetails.insideProgram = false
         this.mixedVisitor = this.initMixedVisitor()
     }
 
@@ -107,6 +96,7 @@ export class AstroTransformer extends Transformer {
             mstr: this.mstr,
             index: this.index,
             content: this.content,
+            scopePath: this.scopePath,
             vars: this.vars.bind(this),
             getRange: this.getRange.bind(this),
             isText: node => node.type === 'text',
@@ -116,7 +106,6 @@ export class AstroTransformer extends Transformer {
             getTextContent: node => node.value,
             getCommentData: node => node.value.trim(),
             visitFunc: this.visitAs.bind(this),
-            fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (index, hasExprs, nestedRanges, lastChildEnd) => {
                 const vars = this.vars()
@@ -150,133 +139,129 @@ export class AstroTransformer extends Transformer {
         })
     }
 
-    _parseAndVisitExpr(expr: string, startOffset: number, asScript = false): Message[] {
+    _parseAndVisitExpr(expr: string, startOffset: number, asScript = false): Text[] {
         const [ast, comments] = (asScript ? parseScript : parseExpr)(expr)
         this.comments = comments
         this.mstr.offset = startOffset
-        const msgs = this.visit(ast)
+        const txts = this.visit(ast)
         this.mstr.offset = 0 // restore
-        return msgs
+        return txts
     }
 
-    visitexpression(node: ExpressionNode): Message[] {
+    visitexpression(node: ExpressionNode): Text[] {
         if (!node.children?.length) {
             // can be undefined!
             return []
         }
         let expr = ''
-        const msgs: Message[] = []
+        const txts: Text[] = []
         const { start, end } = this.getRange(node)
         this._saveCorrectedRanges(node.children, end)
-        for (const part of node.children) {
-            if (part.type === 'text') {
-                expr += part.value
-                continue
+        this.inScope({ type: 'expression' }, () => {
+            for (const part of node.children) {
+                if (part.type === 'text') {
+                    expr += part.value
+                    continue
+                }
+                txts.push(...this.visitAs(part))
+                const { start, end } = this.getRange(part)
+                expr += `"${' '.repeat(end - start)}"`
             }
-            msgs.push(...this.visitAs(part))
-            const { start, end } = this.getRange(part)
-            expr += `"${' '.repeat(end - start)}"`
-        }
-        msgs.push(...this._parseAndVisitExpr(expr, start + 1))
-        return msgs
+            txts.push(...this._parseAndVisitExpr(expr, start + 1))
+        })
+        return txts
     }
 
-    _visitChildren = (nodes: Node[], nestable: boolean): Message[] =>
-        this.mixedVisitor.visit({
+    _visitChildren = (nodes: Node[], nestable: boolean): Text[] => {
+        const scope = this.scopePath.at(-1)!
+        return this.mixedVisitor.visit({
             children: nodes,
             nestable,
             commentDirectives: this.commentDirectives,
-            scope: 'markup',
-            element: this.currentElement as string,
-            useComponent: this.currentElement !== 'title',
+            useComponent: scope.type !== 'element' || scope.name !== 'title',
         })
+    }
 
-    visitFragmentNode(node: FragmentNode): Message[] {
+    visitFragmentNode(node: FragmentNode): Text[] {
         return this._visitChildren(node.children, false)
     }
 
-    visitelement(node: ElementNode): Message[] {
-        const currentElement = this.currentElement
-        this.currentElement = node.name
-        const msgs: Message[] = []
-        for (const attrib of node.attributes) {
-            msgs.push(...this.visitAs(attrib))
-        }
-        const { end } = this.getRange(node)
-        this._saveCorrectedRanges(node.children, end)
-        msgs.push(...this._visitChildren(node.children, true))
-        this.currentElement = currentElement
-        return msgs
+    visitelement(node: ElementNode): Text[] {
+        return this.inScope({ type: 'element', name: node.name }, () => {
+            const txts: Text[] = []
+            for (const attrib of node.attributes) {
+                txts.push(...this.visitAs(attrib))
+            }
+            const { end } = this.getRange(node)
+            this._saveCorrectedRanges(node.children, end)
+            txts.push(...this._visitChildren(node.children, true))
+            return txts
+        })
     }
 
-    visitcomponent(node: ComponentNode): Message[] {
+    visitcomponent(node: ComponentNode): Text[] {
         return this.visitelement(node as unknown as ElementNode)
     }
 
-    'visitcustom-element'(node: CustomElementNode): Message[] {
+    'visitcustom-element'(node: CustomElementNode): Text[] {
         return this.visitelement(node as unknown as ElementNode)
     }
 
-    visitattribute(node: AttributeNode): Message[] {
-        const heurBase: HeuristicDetailsBase = {
-            scope: 'attribute',
-            element: this.currentElement,
-            attribute: node.name,
-        }
+    visitattribute(node: AttributeNode): Text[] {
         let { start } = this.getRange(node)
         if (node.kind === 'spread') {
-            return this._parseAndVisitExpr(node.name, start)
+            return this.inScope({ type: 'attribute', name: '...' }, () => this._parseAndVisitExpr(node.name, start))
         }
-        if (node.kind !== 'empty') {
-            start = this.content.indexOf('=', start) + 1
-        }
-        if (node.kind === 'quoted') {
-            const [pass, msgInfo] = this.checkHeuristicAllowNew(node.value, heurBase)
-            if (!pass) {
-                return []
+        return this.inScope({ type: 'attribute', name: node.name }, () => {
+            if (node.kind !== 'empty') {
+                start = this.content.indexOf('=', start) + 1
             }
-            this.mstr.update(start, start + node.value.length + 2, `{${this.literalRepl(msgInfo)}}`)
-            return [msgInfo]
-        }
-        if (node.kind === 'expression') {
-            heurBase.scope = 'script'
-            start = this.content.indexOf(node.value, start)
-            let expr = node.value
-            if (expr.startsWith('...')) {
-                start += 3
-                expr = expr.slice(3)
+            if (node.kind === 'quoted') {
+                const [pass, msgInfo] = this.checkHeuristicAllowNew(node.value)
+                if (!pass) {
+                    return []
+                }
+                this.mstr.update(start, start + node.value.length + 2, `{${this.literalRepl(msgInfo)}}`)
+                return [msgInfo]
             }
-            return this._parseAndVisitExpr(expr, start)
-        }
-        return []
+            if (node.kind === 'expression') {
+                start = this.content.indexOf(node.value, start)
+                let expr = node.value
+                if (expr.startsWith('...')) {
+                    start += 3
+                    expr = expr.slice(3)
+                }
+                return this._parseAndVisitExpr(expr, start)
+            }
+            return []
+        })
     }
 
-    visitfrontmatter(node: FrontmatterNode): Message[] {
+    visitfrontmatter(node: FrontmatterNode): Text[] {
         const { start } = this.getRange(node)
         this.frontMatterStart = this.content.indexOf('---', start) + 3
         return this._parseAndVisitExpr(node.value, this.frontMatterStart, true)
     }
 
-    visitroot(node: RootNode): Message[] {
+    visitroot(node: RootNode): Text[] {
         // node.children can be undefined!
         const children = node.children ?? []
         this._saveCorrectedRanges(children, this.content.length)
-        const msgs = [...this._visitChildren(children, false)]
-        return msgs
+        return this.inScope({ type: 'element', name: '' }, () => this._visitChildren(children, false))
     }
 
-    visitAs(node: Node | AttributeNode | Estree.AnyNode): Message[] {
+    visitAs(node: Node | AttributeNode | Estree.AnyNode): Text[] {
         return this.visit(node as Estree.AnyNode)
     }
 
     async transformAs(): Promise<TransformOutput> {
         const { ast } = await parse(this.content)
-        const msgs = this.visitAs(ast)
+        const txts = this.visitAs(ast)
         if (this.frontMatterStart == null) {
             this.mstr.appendLeft(0, '---\n')
             this.mstr.appendRight(0, '---\n')
         }
         const header = [`import ${rtRenderFunc} from "@wuchale/astro/runtime.js"`, this.initRuntime()].join('\n')
-        return this.finalize(msgs, this.frontMatterStart ?? 0, header)
+        return this.finalize(txts, this.frontMatterStart ?? 0, header)
     }
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -14,15 +14,16 @@ import { type JSXLib, JSXTransformer } from './transformer.js'
 
 export function createJsxHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
     const defaultHeuristic = createHeuristic(opts)
-    return msg => {
-        const defRes = defaultHeuristic(msg)
+    return (txt, file) => {
+        const defRes = defaultHeuristic(txt, file)
         if (!defRes) {
             return false
         }
-        if (msg.details.scope !== 'script') {
+        const scopeType = txt.path.at(-1)?.type
+        if (scopeType === 'attribute' || scopeType === 'element') {
             return defRes
         }
-        if (msg.details.declaring === 'variable') {
+        if (!txt.path.some(s => s.type === 'function' || s.type === 'funcexpr' || s.type === 'class')) {
             return false
         }
         return defRes

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -8,7 +8,7 @@ import type {
     RuntimeConf,
 } from 'wuchale'
 import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
-import { loaderPathResolver } from 'wuchale/adapter-utils'
+import { getFuncNameNested, loaderPathResolver } from 'wuchale/adapter-utils'
 import { getDefaultLoaderPath as getDefaultLoaderPathVanilla, pluralPattern } from 'wuchale/adapter-vanilla'
 import { type JSXLib, JSXTransformer } from './transformer.js'
 
@@ -39,7 +39,8 @@ export type JSXArgs = AdapterArgs<LoadersAvailable> & {
 }
 
 const defaultRuntime: RuntimeConf = {
-    initReactive: ({ funcName, nested }) => {
+    initReactive: path => {
+        const [funcName, nested] = getFuncNameNested(path)
         const inTopLevel = funcName == null
         const insideReactive =
             !inTopLevel &&
@@ -47,10 +48,14 @@ const defaultRuntime: RuntimeConf = {
             ((funcName.startsWith('use') && funcName.length > 3) || /[A-Z]/.test(funcName[0]!))
         return inTopLevel ? null : insideReactive
     },
-    useReactive: ({ funcName, nested }) =>
-        funcName != null &&
-        !nested &&
-        ((funcName.startsWith('use') && funcName.length > 3) || /[A-Z]/.test(funcName[0]!)),
+    useReactive: path => {
+        const [funcName, nested] = getFuncNameNested(path)
+        return (
+            funcName != null &&
+            !nested &&
+            ((funcName.startsWith('use') && funcName.length > 3) || /[A-Z]/.test(funcName[0]!))
+        )
+    },
     reactive: {
         wrapInit: expr => expr,
         wrapUse: expr => expr,
@@ -63,7 +68,7 @@ const defaultRuntime: RuntimeConf = {
 
 export const defaultRuntimeSolid: RuntimeConf = {
     ...defaultRuntime,
-    initReactive: ({ funcName }) => (funcName == null ? true : null), // init only in top level
+    initReactive: path => (getFuncNameNested(path)[0] == null ? true : null), // init only in top level
     useReactive: true, // always reactive, because solidjs doesn't have a problem with it
     reactive: {
         wrapInit: expr => `() => ${expr}`,

--- a/packages/jsx/src/transformer.test.ts
+++ b/packages/jsx/src/transformer.test.ts
@@ -211,7 +211,7 @@ test('Plural', async t => {
                 return <p>{plural(items, _w_runtime_.p(0), _w_runtime_._.p)}</p>
             }
     `,
-        [{ msgStr: ['One item', '# items'] }],
+        [{ body: ['One item', '# items'] }],
     )
 })
 
@@ -223,7 +223,7 @@ test('Nested and mixed', async (t: TestContext) => {
             </>
         }
     `)
-    t.assert.deepStrictEqual(out.msgs[0]?.placeholders, [['0.0.0', 'appName']])
+    t.assert.deepStrictEqual(out.txts[0]?.placeholders, [['0.0.0', 'appName']])
     transformTest(
         t,
         out,

--- a/packages/jsx/src/transformer.ts
+++ b/packages/jsx/src/transformer.ts
@@ -2,7 +2,7 @@ import { tsPlugin } from '@sveltejs/acorn-typescript'
 import type * as Estree from 'acorn'
 import { Parser } from 'acorn'
 import type * as JX from 'estree-jsx'
-import type { CodePattern, HeuristicFunc, Message, RuntimeConf, TransformCtx, TransformOutput } from 'wuchale'
+import type { CodePattern, HeuristicFunc, RuntimeConf, Text, TransformCtx, TransformOutput } from 'wuchale'
 import { MixedVisitor, type ModFunc } from 'wuchale/adapter-utils'
 import { parseScript, scriptParseOptionsWithComments, Transformer } from 'wuchale/adapter-vanilla'
 
@@ -23,7 +23,6 @@ export type JSXLib = 'default' | 'solidjs'
 
 export class JSXTransformer extends Transformer {
     // state
-    currentElement?: string | undefined
     lastVisitIsComment: boolean = false
     currentJsxKey?: number
 
@@ -39,6 +38,7 @@ export class JSXTransformer extends Transformer {
             mstr: this.mstr,
             index: this.index,
             content: this.content,
+            scopePath: this.scopePath,
             vars: this.vars.bind(this),
             getRange: node => ({
                 start: node.start,
@@ -54,7 +54,6 @@ export class JSXTransformer extends Transformer {
             getTextContent: node => node.value,
             getCommentData: node => this.getMarkupCommentBody(node.expression as JX.JSXEmptyExpression),
             visitFunc: this.visitJx.bind(this),
-            fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (index, hasExprs, nestedRanges, lastChildEnd) => {
                 const vars = this.vars()
@@ -89,22 +88,13 @@ export class JSXTransformer extends Transformer {
         })
     }
 
-    visitChildrenJ(node: JX.JSXElement | JX.JSXFragment, nestable: boolean, addMod?: ModFunc): Message[] {
-        const prevInsideProg = this.heuristciDetails.insideProgram
-        this.heuristciDetails.insideProgram = false
-        const msgs = this.mixedVisitor.visit({
+    visitChildrenJ(node: JX.JSXElement | JX.JSXFragment, nestable: boolean, addMod?: ModFunc): Text[] {
+        return this.mixedVisitor.visit({
             children: node.children,
             nestable,
             commentDirectives: this.commentDirectives,
-            scope: 'markup',
-            element: this.currentElement as string,
             addMod,
         })
-        if (prevInsideProg) {
-            msgs.push(...this.mixedVisitor.applyMod('markup'))
-        }
-        this.heuristciDetails.insideProgram = prevInsideProg // restore
-        return msgs
     }
 
     visitNameJSXNamespacedName(node: JX.JSXNamespacedName): string {
@@ -123,36 +113,33 @@ export class JSXTransformer extends Transformer {
         return this[`visitName${node.type}` as `visitName${typeof node.type}`](node as any)
     }
 
-    visitJSXElement(node: JX.JSXElement): Message[] {
-        const currentElement = this.currentElement
-        this.currentElement = this.visitName(node.openingElement.name)
-        let addMod: ModFunc | undefined
-        const key = node.openingElement.attributes.find(
-            attr => attr.type === 'JSXAttribute' && attr.name.name === 'key',
-        )
-        if (!key) {
-            addMod = nested => {
-                if (!nested || this.currentJsxKey == null) {
-                    return
+    visitJSXElement(node: JX.JSXElement): Text[] {
+        const alreadyInElement = this.scopePath.at(-1)!.type === 'element'
+        return this.inScope({ type: 'element', name: this.visitName(node.openingElement.name) }, () => {
+            let addMod: ModFunc | undefined
+            const key = node.openingElement.attributes.find(
+                attr => attr.type === 'JSXAttribute' && attr.name.name === 'key',
+            )
+            if (!key) {
+                addMod = nested => {
+                    if (!nested || this.currentJsxKey == null) {
+                        return
+                    }
+                    this.mstr.appendLeft(node.openingElement.name.end, ` key="_${this.currentJsxKey}"`)
+                    this.currentJsxKey++
                 }
-                this.mstr.appendLeft(node.openingElement.name.end, ` key="_${this.currentJsxKey}"`)
-                this.currentJsxKey++
             }
-        }
-        const msgs = this.visitChildrenJ(node, true, addMod)
-        for (const attr of node.openingElement.attributes) {
-            msgs.push(...this.visitJx(attr))
-        }
-        this.currentElement = currentElement
-        return msgs
+            const txts = this.visitChildrenJ(node, alreadyInElement, addMod)
+            for (const attr of node.openingElement.attributes) {
+                txts.push(...this.visitJx(attr))
+            }
+            return txts
+        })
     }
 
-    visitJSXFragment(node: JX.JSXFragment): Message[] {
-        const currentElement = this.currentElement
-        this.currentElement = ''
-        const msgs = this.visitChildrenJ(node, true)
-        this.currentElement = currentElement
-        return msgs
+    visitJSXFragment(node: JX.JSXFragment): Text[] {
+        const alreadyInElement = this.scopePath.at(-1)!.type === 'element'
+        return this.inScope({ type: 'element', name: '' }, () => this.visitChildrenJ(node, alreadyInElement))
     }
 
     getMarkupCommentBody(node: JX.JSXEmptyExpression): string {
@@ -163,11 +150,11 @@ export class JSXTransformer extends Transformer {
         return comment.slice(2, -2).trim()
     }
 
-    visitJSXExpressionContainer = (node: JX.JSXExpressionContainer): Message[] => {
-        return this.visit(node.expression as Estree.Expression)
+    visitJSXExpressionContainer = (node: JX.JSXExpressionContainer): Text[] => {
+        return this.inScopeVisit({ type: 'expression' }, node.expression as Estree.Expression)
     }
 
-    visitJSXAttribute(node: JX.JSXAttribute): Message[] {
+    visitJSXAttribute(node: JX.JSXAttribute): Text[] {
         if (node.value == null) {
             return []
         }
@@ -177,59 +164,54 @@ export class JSXTransformer extends Transformer {
         } else {
             name = node.name.name.name
         }
-        const heurBase = {
-            scope: 'script' as 'script',
-            element: this.currentElement,
-            attribute: name,
-        }
-        if (node.value.type !== 'Literal') {
-            if (node.value.type === 'JSXExpressionContainer') {
-                if (node.value.expression.type === 'Literal' && typeof node.value.expression.value === 'string') {
-                    const expr = node.value.expression as Estree.Literal
-                    return this.visitWithCommentDirectives(expr, () => this.visitLiteral(expr, heurBase))
-                }
-                if (node.value.expression.type === 'TemplateLiteral') {
-                    const expr = node.value.expression as Estree.TemplateLiteral
-                    return this.visitWithCommentDirectives(expr, () => this.visitTemplateLiteral(expr, heurBase))
-                }
-            }
-            return this.visitJx(node.value)
-        }
-        if (typeof node.value.value !== 'string') {
-            return []
-        }
         const value = node.value
-        const [pass, msgInfo] = this.checkHeuristicAllowNew(node.value.value, heurBase)
-        if (!pass) {
-            return []
-        }
-        this.mstr.update(value.start, value.end, `{${this.literalRepl(msgInfo)}}`)
-        return [msgInfo]
+        return this.inScope({ type: 'attribute', name }, () => {
+            if (value.type !== 'Literal') {
+                if (value.type === 'JSXExpressionContainer') {
+                    if (value.expression.type === 'Literal' && typeof value.expression.value === 'string') {
+                        const expr = value.expression as Estree.Literal
+                        return this.visitWithCommentDirectives(expr, () => this.visitLiteral(expr))
+                    }
+                    if (value.expression.type === 'TemplateLiteral') {
+                        const expr = value.expression as Estree.TemplateLiteral
+                        return this.visitWithCommentDirectives(expr, () => this.visitTemplateLiteral(expr))
+                    }
+                }
+                return this.visitJx(value)
+            }
+            if (typeof value.value !== 'string') {
+                return []
+            }
+            const [pass, txt] = this.checkHeuristicAllowNew(value.value)
+            if (!pass) {
+                return []
+            }
+            this.mstr.update(value.start, value.end, `{${this.literalRepl(txt)}}`)
+            return [txt]
+        })
     }
 
-    visitJSXSpreadAttribute(node: JX.JSXSpreadAttribute): Message[] {
-        return this.visit(node.argument as Estree.Expression)
+    visitJSXSpreadAttribute(node: JX.JSXSpreadAttribute): Text[] {
+        return this.inScopeVisit({ type: 'attribute', name: '...' }, node.argument as Estree.Expression)
     }
 
-    visitJx(node: JX.Node | JX.JSXSpreadChild | Estree.Program): Message[] {
+    visitJx(node: JX.Node | JX.JSXSpreadChild | Estree.Program): Text[] {
         return this.visit(node as Estree.AnyNode)
     }
 
     transformJx(lib: JSXLib): TransformOutput {
         // jsx vs type casting is not ambiguous in all files except .ts files
-        const [ast, comments] = (this.heuristciDetails.file.endsWith('.ts') ? parseScript : parseScriptJSX)(
-            this.content,
-        )
+        const [ast, comments] = (this.filename.endsWith('.ts') ? parseScript : parseScriptJSX)(this.content)
         this.comments = comments
         if (lib === 'default') {
             this.currentJsxKey = 0
         }
-        const msgs = this.visitJx(ast)
+        const txts = this.visitJx(ast)
         const header = [
             `import ${rtComponent} from "@wuchale/jsx/runtime${lib === 'solidjs' ? '.solid' : ''}.jsx"`,
             this.initRuntime(),
         ].join('\n')
         const bodyStart = this.getRealBodyStart(ast.body) as number
-        return this.finalize(msgs, bodyStart, header)
+        return this.finalize(txts, bodyStart, header)
     }
 }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -16,18 +16,13 @@ export type { RuntimeCtxSv }
 
 export function createSvelteHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
     const defaultHeuristic = createHeuristic(opts)
-    return msg => {
-        const defRes = defaultHeuristic(msg)
-        if (!defRes) {
-            return false
+    return (txt, file) => {
+        for (const s of txt.path) {
+            if (s.type === 'call' && s.name === '$inspect') {
+                return false
+            }
         }
-        if (msg.details.scope !== 'script') {
-            return defRes
-        }
-        if (msg.details.call === '$inspect') {
-            return false
-        }
-        return defRes
+        return defaultHeuristic(txt, file)
     }
 }
 
@@ -37,24 +32,6 @@ export const svelteKitDefaultHeuristic = createSvelteHeuristic({
     ...defaultHeuristicOpts,
     urlCalls: ['asset', 'goto', 'pushState', 'replaceState', 'resolve'],
 })
-
-/** Default Svelte heuristic which requires `$derived` or `$derived.by` for top level variable assignments */
-export const svelteDefaultHeuristicDerivedReq: HeuristicFunc = msg => {
-    const defRes = svelteDefaultHeuristic(msg)
-    if (!defRes) {
-        return false
-    }
-    if (msg.details.scope !== 'script' || msg.details.declaring !== 'variable') {
-        return defRes
-    }
-    if (!msg.details.topLevelCall) {
-        return false
-    }
-    if (['$derived', '$derived.by'].includes(msg.details.topLevelCall)) {
-        return defRes
-    }
-    return false
-}
 
 type LoadersAvailable = 'svelte' | 'sveltekit'
 

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,14 +1,6 @@
-import type {
-    Adapter,
-    AdapterArgs,
-    CreateHeuristicOpts,
-    DecideReactiveDetails,
-    DeepPartial,
-    HeuristicFunc,
-    LoaderChoice,
-} from 'wuchale'
+import type { Adapter, AdapterArgs, CreateHeuristicOpts, DeepPartial, HeuristicFunc, LoaderChoice } from 'wuchale'
 import { createHeuristic, defaultHeuristicOpts, fillDefaults, pofile } from 'wuchale'
-import { loaderPathResolver } from 'wuchale/adapter-utils'
+import { getFuncNameNested, loaderPathResolver } from 'wuchale/adapter-utils'
 import { pluralPattern } from 'wuchale/adapter-vanilla'
 import { type RuntimeCtxSv, SvelteTransformer } from './transformer.js'
 
@@ -37,8 +29,6 @@ type LoadersAvailable = 'svelte' | 'sveltekit'
 
 export type SvelteArgs = AdapterArgs<LoadersAvailable>
 
-type DecideRxDetails = DecideReactiveDetails<RuntimeCtxSv>
-
 export const defaultArgs: SvelteArgs = {
     files: ['src/**/*.svelte', 'src/**/*.svelte.{js,ts}'],
     storage: pofile(),
@@ -51,13 +41,14 @@ export const defaultArgs: SvelteArgs = {
     },
     loader: 'svelte',
     runtime: {
-        initReactive: ({ file, funcName, ctx: { module } }: DecideRxDetails) => {
+        initReactive: (path, file, { module }: RuntimeCtxSv) => {
+            const [funcName] = getFuncNameNested(path)
             const inTopLevel = funcName == null
             return file.endsWith('.svelte.js') || module ? inTopLevel : inTopLevel ? true : null
         },
-        useReactive: ({ file, funcName, ctx: { module } }: DecideRxDetails) => {
-            const inTopLevel = funcName == null
-            return file.endsWith('.svelte.js') || module ? inTopLevel : true
+        useReactive: (path, file, { module }: RuntimeCtxSv) => {
+            const [funcName] = getFuncNameNested(path)
+            return file.endsWith('.svelte.js') || module ? funcName == null : true
         },
         reactive: {
             wrapInit: expr => `$derived(${expr})`,

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -64,7 +64,7 @@ test('JS module files', async t => {
             'No translation!' // simple expression
             const alreadyDerived = $derived(call('Foo'))
             noExtract('Foo')
-            const msg = $derived('Hello')
+            const txt = $derived('Hello')
 
             function foo() {
                 return 'Should extract'
@@ -80,7 +80,7 @@ test('JS module files', async t => {
         'No translation!' // simple expression
         const alreadyDerived = $derived(call(_w_runtime_(1)))
         noExtract('Foo')
-        const msg = $derived(_w_runtime_(2))
+        const txt = $derived(_w_runtime_(2))
 
         function foo() {
             const _w_runtime_ = _w_load_();
@@ -241,14 +241,14 @@ test('URLs', async t => {
         <a href={_w_localize_(_w_runtime_(6), _w_runtime_.l)}>{_w_runtime_(7)}</a>
     `,
         [
-            { msgStr: ['/translated/{0}'], type: 'url' },
-            { msgStr: ['/translated/somewhere/{0}'], type: 'url' },
-            { msgStr: ['/translated/propertyhref'], type: 'url' },
-            { msgStr: ['/translated/hello'], type: 'url' },
-            { msgStr: ['/translated/hello/there'], type: 'url' },
-            { msgStr: ['/translated/very/deep/link/{0}'], type: 'url' },
-            { msgStr: ['/translated/{0}'], type: 'url' },
-            { msgStr: ['/'], type: 'url' },
+            { body: ['/translated/{0}'], type: 'url' },
+            { body: ['/translated/somewhere/{0}'], type: 'url' },
+            { body: ['/translated/propertyhref'], type: 'url' },
+            { body: ['/translated/hello'], type: 'url' },
+            { body: ['/translated/hello/there'], type: 'url' },
+            { body: ['/translated/very/deep/link/{0}'], type: 'url' },
+            { body: ['/translated/{0}'], type: 'url' },
+            { body: ['/'], type: 'url' },
             'Hello',
             'Hello',
             'Hello',
@@ -284,7 +284,7 @@ test('Exported snippet', async t => {
         <script module>
             export const bar = {
                 feel: () => {
-					const msg = 'Hello'
+					const txt = 'Hello'
                     return foo
                 }
             }
@@ -302,7 +302,7 @@ test('Exported snippet', async t => {
             export const bar = {
                 feel: () => {
 					const _w_runtime_mod_ = _w_load_();
-					const msg = _w_runtime_mod_(0)
+					const txt = _w_runtime_mod_(0)
                     return foo
                 }
             }
@@ -345,10 +345,10 @@ test('Context', async t => {
             {_w_runtime_(2)}
     `,
         [
-            { msgStr: ['String'], context: 'music' },
-            { msgStr: ['String'], context: 'programming' },
-            { msgStr: ['Close'], context: 'door' },
-            { msgStr: ['Close'], context: 'distance' },
+            { body: ['String'], context: 'music' },
+            { body: ['String'], context: 'programming' },
+            { body: ['Close'], context: 'door' },
+            { body: ['Close'], context: 'distance' },
         ],
     )
 })
@@ -488,11 +488,11 @@ test('Collapsing deep nested messages with declaration tags', async t => {
         `,
         [
             {
-                msgStr: ['user {0}'],
+                body: ['user {0}'],
                 placeholders: [['0', 'user']],
             },
             {
-                msgStr: ['Hello <0>there <0>someone</0> <1/> {0}</0> and <1/>'],
+                body: ['Hello <0>there <0>someone</0> <1/> {0}</0> and <1/>'],
                 placeholders: [['0.0', 'varName']],
             },
         ],

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -39,6 +39,7 @@ export class SvelteTransformer extends Transformer {
     // state
     currentSnippet = 0
     moduleExportExprs: AnyNode[] = [] // to choose which runtime var to use for snippets
+    override runtimeCtx: RuntimeCtxSv = { module: false }
 
     mixedVisitor: MixedVisitorSvelte
 
@@ -69,7 +70,10 @@ export class SvelteTransformer extends Transformer {
                     if (s.left) {
                         return false
                     }
-                } else if (s.type === 'call' && (noWrapTopCalls.includes(s.name) || noWrapTopCalls.some(c => s.name.startsWith(`${c}.`)))) {
+                } else if (
+                    s.type === 'call' &&
+                    (noWrapTopCalls.includes(s.name) || noWrapTopCalls.some(c => s.name.startsWith(`${c}.`)))
+                ) {
                     return false
                 }
             }

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -9,15 +9,7 @@ import type {
     VariableDeclarator,
 } from 'acorn'
 import { type AST, type Preprocessor, parse, preprocess } from 'svelte/compiler'
-import type {
-    CodePattern,
-    HeuristicDetailsBase,
-    HeuristicFunc,
-    Message,
-    RuntimeConf,
-    TransformCtx,
-    TransformOutput,
-} from 'wuchale'
+import type { CodePattern, HeuristicFunc, RuntimeConf, Text, TransformCtx, TransformOutput } from 'wuchale'
 import { MixedVisitor, varNames } from 'wuchale/adapter-utils'
 import { parseScript, Transformer } from 'wuchale/adapter-vanilla'
 
@@ -45,7 +37,6 @@ export type RuntimeCtxSv = {
 
 export class SvelteTransformer extends Transformer {
     // state
-    currentElement?: string | undefined
     currentSnippet = 0
     moduleExportExprs: AnyNode[] = [] // to choose which runtime var to use for snippets
 
@@ -53,48 +44,46 @@ export class SvelteTransformer extends Transformer {
 
     constructor(ctx: TransformCtx, heuristic: HeuristicFunc, patterns: CodePattern[], rtConf: RuntimeConf) {
         super(ctx, heuristic, patterns, rtConf, [varNames.rt, rtModuleVar])
-        this.heuristciDetails.insideProgram = false
         this.mixedVisitor = this.initMixedVisitor()
     }
 
-    visitExpressionTag(node: AST.ExpressionTag): Message[] {
-        return this.visit(node.expression as AnyNode)
+    visitExpressionTag(node: AST.ExpressionTag): Text[] {
+        return this.inScopeVisit({ type: 'expression' }, node.expression as AnyNode)
     }
 
-    override visitVariableDeclarator(node: VariableDeclarator): Message[] {
-        const msgs = super.visitVariableDeclarator(node)
+    override visitVariableDeclarator(node: VariableDeclarator): Text[] {
+        const txts = super.visitVariableDeclarator(node)
         const init = node.init
         if (
-            !msgs.length ||
-            (this.heuristciDetails.declaring != null && this.heuristciDetails.declaring !== 'variable') ||
+            !txts.length ||
+            this.scopePath.some(s => s.type === 'assignment') ||
             init == null ||
             init.type === 'ArrowFunctionExpression' ||
             init.type === 'FunctionExpression'
         ) {
-            return msgs
+            return txts
         }
-        const needsWrapping = msgs.some(msg => {
-            if (msg.details.leftSide) {
-                return false
-            }
-            const call = msg.details.topLevelCall ?? msg.details.call ?? ''
-            if (noWrapTopCalls.includes(call) || noWrapTopCalls.some(c => call.startsWith(`${c}.`))) {
-                return false
-            }
-            if (msg.details.declaring !== 'variable') {
-                return false
+        const needsWrapping = txts.some(txt => {
+            for (const s of txt.path) {
+                if (s.type === 'assignment') {
+                    if (s.left) {
+                        return false
+                    }
+                } else if (s.type === 'call' && (noWrapTopCalls.includes(s.name) || noWrapTopCalls.some(c => s.name.startsWith(`${c}.`)))) {
+                    return false
+                }
             }
             return true
         })
         if (!needsWrapping) {
-            return msgs
+            return txts
         }
         const isExported = this.moduleExportExprs.some(node => init.start >= node.start && init.end <= node.end)
         if (!isExported && this.initReactive()) {
             this.mstr.appendLeft(init.start, '$derived(')
             this.mstr.appendRight(init.end, ')')
         }
-        return msgs
+        return txts
     }
 
     initMixedVisitor(): MixedVisitorSvelte {
@@ -102,6 +91,7 @@ export class SvelteTransformer extends Transformer {
             mstr: this.mstr,
             index: this.index,
             content: this.content,
+            scopePath: this.scopePath,
             vars: this.vars.bind(this),
             getRange: node => ({ start: node.start, end: node.end }),
             isText: node => node.type === 'Text',
@@ -111,7 +101,6 @@ export class SvelteTransformer extends Transformer {
             getTextContent: node => node.data,
             getCommentData: node => node.data.trim(),
             visitFunc: this.visitSv.bind(this),
-            fullHeuristicDetails: this.fullHeuristicDetails.bind(this),
             checkHeuristic: this.getHeuristicMessageType.bind(this),
             wrapNested: (index, hasExprs, nestedRanges, lastChildEnd) => {
                 const snippets: string[] = []
@@ -147,38 +136,36 @@ export class SvelteTransformer extends Transformer {
         })
     }
 
-    visitFragment(node: AST.Fragment, nestable = false): Message[] {
+    visitFragment(node: AST.Fragment, nestable = false): Text[] {
+        const scope = this.scopePath.at(-1)!
         return this.mixedVisitor.visit({
             children: node.nodes,
             nestable,
             commentDirectives: this.commentDirectives,
-            scope: 'markup',
-            element: this.currentElement as string,
-            useComponent: this.currentElement !== 'title',
+            useComponent: scope.type !== 'element' || scope.name !== 'title',
         })
     }
 
-    visitRegularElement(node: AST.ElementLike): Message[] {
-        const currentElement = this.currentElement
-        this.currentElement = node.name
-        const msgs: Message[] = []
-        for (const attrib of node.attributes) {
-            msgs.push(...this.visitSv(attrib))
-        }
-        msgs.push(...this.visitFragment(node.fragment, true))
-        this.currentElement = currentElement
-        return msgs
+    visitRegularElement(node: AST.ElementLike): Text[] {
+        return this.inScope({ type: 'element', name: node.name }, () => {
+            const txts: Text[] = []
+            for (const attrib of node.attributes) {
+                txts.push(...this.visitSv(attrib))
+            }
+            txts.push(...this.visitFragment(node.fragment, true))
+            return txts
+        })
     }
 
     visitComponent(node: AST.Component) {
         return this.visitRegularElement(node)
     }
 
-    visitSpreadAttribute(node: AST.SpreadAttribute): Message[] {
-        return this.visit(node.expression as AnyNode)
+    visitSpreadAttribute(node: AST.SpreadAttribute): Text[] {
+        return this.inScopeVisit({ type: 'attribute', name: '...' }, node.expression as AnyNode)
     }
 
-    visitAttribute(node: AST.Attribute): Message[] {
+    visitAttribute(node: AST.Attribute): Text[] {
         if (node.value === true) {
             return []
         }
@@ -188,71 +175,58 @@ export class SvelteTransformer extends Transformer {
         } else {
             values = [node.value]
         }
-        if (values.length > 1) {
-            const msgs = this.mixedVisitor.visit({
-                children: values,
-                nestable: false,
-                commentDirectives: this.commentDirectives,
-                scope: 'attribute',
-                element: this.currentElement as string,
-                attribute: node.name,
-            })
-            msgs.push(...this.mixedVisitor.applyMod('attribute'))
-            return msgs
-        }
-        const value = values[0]!
-        const heuDetails: HeuristicDetailsBase = {
-            scope: 'script',
-            element: this.currentElement,
-            attribute: node.name,
-        }
-        if (value.type === 'ExpressionTag') {
-            if (value.expression.type === 'Literal') {
-                const expr = value.expression as Literal
-                return this.visitWithCommentDirectives(expr, () => this.visitLiteral(expr, heuDetails))
+        return this.inScope({ type: 'attribute', name: node.name }, () => {
+            if (values.length > 1) {
+                return this.mixedVisitor.visit({
+                    children: values,
+                    nestable: false,
+                    commentDirectives: this.commentDirectives,
+                })
             }
-            if (value.expression.type === 'TemplateLiteral') {
-                const expr = value.expression as TemplateLiteral
-                return this.visitWithCommentDirectives(expr, () => this.visitTemplateLiteral(expr, heuDetails))
+            const value = values[0]!
+            if (value.type === 'ExpressionTag') {
+                if (value.expression.type === 'Literal') {
+                    const expr = value.expression as Literal
+                    return this.visitWithCommentDirectives(expr, () => this.visitLiteral(expr))
+                }
+                if (value.expression.type === 'TemplateLiteral') {
+                    const expr = value.expression as TemplateLiteral
+                    return this.visitWithCommentDirectives(expr, () => this.visitTemplateLiteral(expr))
+                }
+                return this.visitSv(value)
             }
-            return this.visitSv(value)
-        }
-        heuDetails.scope = 'attribute'
-        const [pass, msgInfo] = this.checkHeuristicAllowNew(value.data, heuDetails)
-        if (!pass) {
-            return []
-        }
-        this.mstr.update(value.start, value.end, `{${this.literalRepl(msgInfo)}}`)
-        if (`'"`.includes(this.content[value.start - 1]!)) {
-            this.mstr.remove(value.start - 1, value.start)
-            this.mstr.remove(value.end, value.end + 1)
-        }
-        return [msgInfo]
+            const [pass, txt] = this.checkHeuristicAllowNew(value.data)
+            if (!pass) {
+                return []
+            }
+            this.mstr.update(value.start, value.end, `{${this.literalRepl(txt)}}`)
+            if (`'"`.includes(this.content[value.start - 1]!)) {
+                this.mstr.remove(value.start - 1, value.start)
+                this.mstr.remove(value.end, value.end + 1)
+            }
+            return [txt]
+        })
     }
 
-    visitConstTag(node: AST.ConstTag): Message[] {
+    visitConstTag(node: AST.ConstTag): Text[] {
         // @ts-expect-error
         return this.visitVariableDeclaration(node.declaration)
     }
 
-    visitDeclarationTag(node: AST.DeclarationTag): Message[] {
-        const prevDeclaring = this.heuristciDetails.declaring
-        this.heuristciDetails.declaring = 'variable'
+    visitDeclarationTag(node: AST.DeclarationTag): Text[] {
         // @ts-expect-error
-        const msgs = this.visitVariableDeclaration(node.declaration)
-        this.heuristciDetails.declaring = prevDeclaring
-        return msgs
+        return this.visitVariableDeclaration(node.declaration)
     }
 
-    visitRenderTag(node: AST.RenderTag): Message[] {
+    visitRenderTag(node: AST.RenderTag): Text[] {
         return this.visit(node.expression as Expression)
     }
 
-    visitHtmlTag(node: AST.HtmlTag): Message[] {
+    visitHtmlTag(node: AST.HtmlTag): Text[] {
         return this.visit(node.expression as Expression)
     }
 
-    visitOnDirective(node: AST.OnDirective): Message[] {
+    visitOnDirective(node: AST.OnDirective): Text[] {
         return node.expression ? this.visit(node.expression as Expression) : []
     }
 
@@ -269,100 +243,99 @@ export class SvelteTransformer extends Transformer {
         return Object.values(node).some(value => this.hasIdentifier(value, name))
     }
 
-    visitSnippetBlock(node: AST.SnippetBlock): Message[] {
+    visitSnippetBlock(node: AST.SnippetBlock): Text[] {
         // use module runtime var because the snippet may be exported from the module
         const prevRtVar = this.currentRtVar
         if (this.hasIdentifier(this.moduleExportExprs, node.expression.name)) {
             this.currentRtVar = rtModuleVar
         }
-        const msgs = this.visitFragment(node.body, false)
+        const txts = this.visitFragment(node.body, false)
         this.currentRtVar = prevRtVar
-        return msgs
+        return txts
     }
 
-    visitIfBlock(node: AST.IfBlock): Message[] {
-        const msgs = this.visit(node.test as AnyNode)
-        msgs.push(...this.visitFragment(node.consequent, false))
+    visitIfBlock(node: AST.IfBlock): Text[] {
+        const txts = this.visit(node.test as AnyNode)
+        txts.push(...this.visitFragment(node.consequent, false))
         if (node.alternate) {
-            msgs.push(...this.visitFragment(node.alternate, false))
+            txts.push(...this.visitFragment(node.alternate, false))
         }
-        return msgs
+        return txts
     }
 
-    visitEachBlock(node: AST.EachBlock): Message[] {
-        const msgs = [...this.visit(node.expression as AnyNode), ...this.visitFragment(node.body, false)]
+    visitEachBlock(node: AST.EachBlock): Text[] {
+        const txts = [...this.visit(node.expression as AnyNode), ...this.visitFragment(node.body, false)]
         if (node.key) {
-            msgs.push(...this.visit(node.key as AnyNode))
+            txts.push(...this.visit(node.key as AnyNode))
         }
         if (node.fallback) {
-            msgs.push(...this.visitFragment(node.fallback, false))
+            txts.push(...this.visitFragment(node.fallback, false))
         }
-        return msgs
+        return txts
     }
 
-    visitKeyBlock(node: AST.KeyBlock): Message[] {
+    visitKeyBlock(node: AST.KeyBlock): Text[] {
         return [...this.visit(node.expression as AnyNode), ...this.visitFragment(node.fragment, false)]
     }
 
-    visitAwaitBlock(node: AST.AwaitBlock): Message[] {
-        const msgs = this.visit(node.expression as AnyNode)
+    visitAwaitBlock(node: AST.AwaitBlock): Text[] {
+        const txts = this.visit(node.expression as AnyNode)
         if (node.then) {
-            msgs.push(...this.visitFragment(node.then, false))
+            txts.push(...this.visitFragment(node.then, false))
         }
         if (node.pending) {
-            msgs.push(...this.visitFragment(node.pending, false))
+            txts.push(...this.visitFragment(node.pending, false))
         }
         if (node.catch) {
-            msgs.push(...this.visitFragment(node.catch, false))
+            txts.push(...this.visitFragment(node.catch, false))
         }
-        return msgs
+        return txts
     }
 
-    visitSvelteBody(node: AST.SvelteBody): Message[] {
+    visitSvelteBody(node: AST.SvelteBody): Text[] {
         return node.attributes.flatMap(n => this.visitSv(n))
     }
 
-    visitSvelteDocument(node: AST.SvelteDocument): Message[] {
+    visitSvelteDocument(node: AST.SvelteDocument): Text[] {
         return node.attributes.flatMap(n => this.visitSv(n))
     }
 
-    visitSvelteElement(node: AST.SvelteElement): Message[] {
-        const currentElement = this.currentElement
+    visitSvelteElement(node: AST.SvelteElement): Text[] {
+        let name = 'svelte:element'
         if (node.tag.type === 'Literal' && typeof node.tag.value === 'string') {
-            this.currentElement = node.tag.value
-        } else {
-            this.currentElement = 'svelte:element'
+            name = node.tag.value
         }
-        const msgs = [...node.attributes.flatMap(n => this.visitSv(n)), ...this.visitFragment(node.fragment, true)]
-        this.currentElement = currentElement
-        return msgs
+        return this.inScope({ type: 'element', name }, () => [
+            ...node.attributes.flatMap(n => this.visitSv(n)),
+            ...this.visitFragment(node.fragment, true),
+        ])
     }
 
-    visitSvelteBoundary(node: AST.SvelteBoundary): Message[] {
+    visitSvelteBoundary(node: AST.SvelteBoundary): Text[] {
         return [...node.attributes.flatMap(n => this.visitSv(n)), ...this.visitSv(node.fragment)]
     }
 
-    visitSvelteHead(node: AST.SvelteHead): Message[] {
+    visitSvelteHead(node: AST.SvelteHead): Text[] {
         return this.visitSv(node.fragment)
     }
 
-    visitTitleElement(node: AST.TitleElement): Message[] {
+    visitTitleElement(node: AST.TitleElement): Text[] {
         return this.visitRegularElement(node)
     }
 
-    visitSvelteWindow(node: AST.SvelteWindow): Message[] {
+    visitSvelteWindow(node: AST.SvelteWindow): Text[] {
         return node.attributes.flatMap(n => this.visitSv(n))
     }
 
-    visitRoot(node: AST.Root): Message[] {
-        const msgs: Message[] = []
+    visitRoot(node: AST.Root): Text[] {
+        const txts: Text[] = []
         if (node.module) {
             const prevRtVar = this.currentRtVar
             this.currentRtVar = rtModuleVar
             this.runtimeCtx = { module: true }
             this.commentDirectives = {} // reset
             // @ts-expect-error
-            msgs.push(...this.visitProgram(node.module.content))
+            txts.push(...this.visitProgram(node.module.content))
             const runtimeInit = this.initRuntime()
             if (runtimeInit) {
                 this.mstr.appendRight(
@@ -376,13 +349,13 @@ export class SvelteTransformer extends Transformer {
         }
         if (node.instance) {
             this.commentDirectives = {} // reset
-            msgs.push(...this.visitProgram(node.instance.content as Program))
+            txts.push(...this.visitProgram(node.instance.content as Program))
         }
-        msgs.push(...this.visitFragment(node.fragment, false))
-        return msgs
+        txts.push(...this.inScope({ type: 'element', name: '' }, () => this.visitFragment(node.fragment, false)))
+        return txts
     }
 
-    visitSv(node: AST.SvelteNode | AnyNode): Message[] {
+    visitSv(node: AST.SvelteNode | AnyNode): Text[] {
         return this.visit(node as AnyNode)
     }
 
@@ -416,7 +389,7 @@ export class SvelteTransformer extends Transformer {
     }
 
     async transformSv(): Promise<TransformOutput> {
-        const isComponent = this.heuristciDetails.file.endsWith('.svelte')
+        const isComponent = this.filename.endsWith('.svelte')
         let ast: AST.Root | Program
         if (isComponent) {
             const prepd = await preprocess(this.content, { style: removeCSS })
@@ -427,14 +400,14 @@ export class SvelteTransformer extends Transformer {
         if (ast.type === 'Root' && ast.module) {
             this.collectModuleExportExprs(ast.module)
         }
-        const msgs = this.visitSv(ast)
+        const txts = this.visitSv(ast)
         const initRuntime = this.initRuntime()
         if (ast.type === 'Program') {
             const bodyStart = this.getRealBodyStart(ast.body) ?? 0
             if (initRuntime) {
                 this.mstr.appendRight(bodyStart, initRuntime)
             }
-            return this.finalize(msgs, bodyStart)
+            return this.finalize(txts, bodyStart)
         }
         let headerIndex = 0
         if (ast.module) {
@@ -457,6 +430,6 @@ export class SvelteTransformer extends Transformer {
             this.mstr.prependRight(instanceStart, `${initRuntime}\n</script>\n`)
             // now hmr data can be prependRight(0, ...)
         }
-        return this.finalize(msgs, headerIndex, headerAdd)
+        return this.finalize(txts, headerIndex, headerAdd)
     }
 }

--- a/packages/wuchale/src/adapter-utils/index.test.ts
+++ b/packages/wuchale/src/adapter-utils/index.test.ts
@@ -1,0 +1,16 @@
+// $ node --import ../../testing/resolve.ts %f
+
+import { type TestContext, test } from 'node:test'
+import { getFuncNameNested } from './index.js'
+
+test('RT details', (t: TestContext) => {
+    t.assert.deepStrictEqual(
+        getFuncNameNested([
+            { type: 'function', name: 'foo' },
+            { type: 'assignment', left: false, targets: ['bar'] },
+            { type: 'funcexpr', kind: 'arrow' },
+        ]),
+        ['bar', true],
+    )
+    t.assert.deepStrictEqual(getFuncNameNested([{ type: 'function', name: 'foo' }]), ['foo', false])
+})

--- a/packages/wuchale/src/adapter-utils/index.ts
+++ b/packages/wuchale/src/adapter-utils/index.ts
@@ -2,7 +2,7 @@ export { MixedVisitor, type ModFunc } from './mixed-visitor.js'
 
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { HeuristicResultChecked } from '../adapters.js'
+import type { HeuristicResultChecked } from '../text.js'
 
 export const varNames = {
     rt: '_w_runtime_',

--- a/packages/wuchale/src/adapter-utils/index.ts
+++ b/packages/wuchale/src/adapter-utils/index.ts
@@ -2,7 +2,7 @@ export { MixedVisitor, type ModFunc } from './mixed-visitor.js'
 
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import type { HeuristicResultChecked } from '../text.js'
+import { ascendPath, type HeuristicResultChecked, type Scope } from '../text.js'
 
 export const varNames = {
     rt: '_w_runtime_',
@@ -83,4 +83,34 @@ export function restoreCommentDirectives(target: CommentDirectives, original: Co
     for (const key in target) {
         pullDirective(target, original, key as keyof CommentDirectives) // restore
     }
+}
+
+/** for deciding to use reactive runtimes */
+export function getFuncNameNested(path: Scope[]): [string | null, boolean] {
+    let funcName: string | null = null
+    let innerIsArrow = false
+    for (const s of ascendPath(path)) {
+        if (s.type === 'funcexpr') {
+            innerIsArrow = true
+            continue
+        }
+        let func: string
+        if (s.type === 'function') {
+            func = s.name
+        } else if (innerIsArrow) {
+            if (s.type === 'assignment' && !s.left && s.targets.length === 1) {
+                func = s.targets[0]!
+            } else {
+                func = ''
+            }
+            innerIsArrow = false
+        } else {
+            continue
+        }
+        if (funcName) {
+            return [funcName, true]
+        }
+        funcName = func
+    }
+    return [funcName, false]
 }

--- a/packages/wuchale/src/adapter-utils/mixed-visitor.ts
+++ b/packages/wuchale/src/adapter-utils/mixed-visitor.ts
@@ -1,15 +1,8 @@
 // Shared logic between adapters for handling nested / mixed elements within elements / fragments
 
 import type MagicString from 'magic-string'
-import {
-    getKey,
-    type HeuristicDetails,
-    type HeuristicDetailsBase,
-    type HeuristicFunc,
-    type IndexTracker,
-    type Message,
-    newMessage,
-} from '../adapters.js'
+import { getKey, type IndexTracker } from '../adapters.js'
+import { type HeuristicResult, newText, type Scope, type Text } from '../text.js'
 import {
     type CommentDirectives,
     commentPrefix,
@@ -27,6 +20,7 @@ type InitProps<MixNodeT, TxtT extends MixNodeT, ComT extends MixNodeT, ExprT ext
     mstr: MagicString
     index: IndexTracker
     content: string
+    scopePath: Scope[]
     vars: () => RuntimeVars
     getRange: (node: MixNodeT) => Range
     isText: (node: MixNodeT) => node is TxtT
@@ -35,19 +29,16 @@ type InitProps<MixNodeT, TxtT extends MixNodeT, ComT extends MixNodeT, ExprT ext
     leaveInPlace: (node: MixNodeT) => boolean
     getTextContent: (node: TxtT) => string
     getCommentData: (node: ComT) => string
-    visitFunc: (node: MixNodeT) => Message[]
-    fullHeuristicDetails: (details: HeuristicDetailsBase) => HeuristicDetails
-    checkHeuristic: HeuristicFunc
+    visitFunc: (node: MixNodeT) => Text[]
+    checkHeuristic: (txt: Text) => HeuristicResult
     wrapNested: (index: number | null, hasExpr: boolean, nestedRanges: NestedRanges, lastChildEnd: number) => void
 }
-
-export type MixedScope = 'markup' | 'attribute'
 
 export type ModFunc = (nested: boolean, lvlHasMsg: boolean) => void
 
 type LevelMod = {
-    msg: Message | null
-    txts: [Message, () => void][]
+    txt: Text | null
+    txts: [Text, () => void][]
     hasTxtDesc: boolean
     unit: boolean
     pending: boolean
@@ -57,7 +48,7 @@ type LevelMod = {
 }
 
 const newMod = (building = false, unit = false): LevelMod => ({
-    msg: null,
+    txt: null,
     hasTxtDesc: false,
     txts: [],
     building,
@@ -70,9 +61,9 @@ const newMod = (building = false, unit = false): LevelMod => ({
 type TrimOut = [number, string, number]
 
 /** trims from end first */
-function trimText(msgStr: string): TrimOut {
-    const trimmedE = msgStr.trimEnd()
-    const endWh = msgStr.length - trimmedE.length
+function trimText(body: string): TrimOut {
+    const trimmedE = body.trimEnd()
+    const endWh = body.length - trimmedE.length
     const trimmed = trimmedE.trimStart()
     const startWh = trimmedE.length - trimmed.length
     return [startWh, trimmed, endWh]
@@ -82,9 +73,6 @@ type VisitProps<NodeT> = {
     children: NodeT[]
     nestable: boolean
     commentDirectives: CommentDirectives
-    scope: MixedScope
-    element: string
-    attribute?: string
     /** force using component instead of a function call.
      * set to true when variables can be objects that cannot be converted to strings like
      * e.g. components in jsx to prevent `[object Object]` being rendered. */
@@ -100,65 +88,65 @@ export class MixedVisitor<
     ExprT extends MixNodeT,
 > {
     #props: InitProps<MixNodeT, TxtT, ComT, ExprT>
-    #mod = { markup: newMod(), attribute: newMod() }
+    #mod = new Map<Scope['type'], LevelMod>()
 
     constructor(props: InitProps<MixNodeT, TxtT, ComT, ExprT>) {
         this.#props = props
     }
 
-    /** returns false when in dev mode and new messages are not allowed */
-    #checkAllowNewMsg(msg: Message) {
-        return this.#props.index.has(getKey(msg.msgStr, msg.context))
+    /** returns false when in dev mode and new txts are not allowed */
+    #checkAllowNewMsg(txt: Text) {
+        return this.#props.index.has(getKey(txt.body, txt.context))
     }
 
     #applyMod(mod: LevelMod, depth = 0) {
         if (!mod.pending) {
             return []
         }
-        const msgs: Message[] = []
+        const txts: Text[] = []
         const nested = depth > 0
         let modify = nested
         if (!nested) {
-            if (mod.msg) {
+            if (mod.txt) {
                 if (mod.unit) {
-                    mod.msg.type = 'message'
+                    mod.txt.type = 'message'
                     modify = true
                 } else if (mod.building) {
-                    const heurMsgType = this.#props.checkHeuristic(mod.msg)
-                    if (heurMsgType && this.#checkAllowNewMsg(mod.msg)) {
-                        mod.msg.type = heurMsgType
+                    const heurMsgType = this.#props.checkHeuristic(mod.txt)
+                    if (heurMsgType && this.#checkAllowNewMsg(mod.txt)) {
+                        mod.txt.type = heurMsgType
                         modify = true
                     }
                 }
-                modify && msgs.push(mod.msg)
+                modify && txts.push(mod.txt)
             }
             if (!modify) {
-                for (const [msg, func] of mod.txts) {
-                    if (!this.#checkAllowNewMsg(msg)) {
+                for (const [txt, func] of mod.txts) {
+                    if (!this.#checkAllowNewMsg(txt)) {
                         continue
                     }
-                    msgs.push(msg)
+                    txts.push(txt)
                     func()
                 }
             }
         }
         if (modify) {
             for (const func of mod.funcs) {
-                func(nested, mod.msg != null)
+                func(nested, mod.txt != null)
             }
         }
         for (const childMod of mod.children) {
-            msgs.push(...this.#applyMod(childMod, depth + (modify ? 1 : 0)))
+            txts.push(...this.#applyMod(childMod, depth + (modify ? 1 : 0)))
         }
         mod.pending = false
-        return msgs
+        return txts
     }
 
-    applyMod(scope: MixedScope = 'markup') {
-        const mod = this.#mod[scope]
-        const msgs = this.#applyMod(mod)
-        this.#mod[scope] = newMod() // in addition to pending for when called for last cleanup
-        return msgs
+    #applyModClear(scope: Scope['type'] = 'element') {
+        const mod = this.#mod.get(scope)!
+        const txts = this.#applyMod(mod)
+        this.#mod.set(scope, newMod())
+        return txts
     }
 
     #getLastChildEnd(children: MixNodeT[]): number {
@@ -171,14 +159,10 @@ export class MixedVisitor<
         return lastChildEnd
     }
 
-    #makeMsg(props: VisitProps<MixNodeT>, msgStr: string, placeholders: [string, string][] = []) {
-        return newMessage({
-            msgStr: [msgStr.trim()],
-            details: this.#props.fullHeuristicDetails({
-                scope: props.scope,
-                element: props.element,
-                attribute: props.attribute,
-            }),
+    #makeTxt(props: VisitProps<MixNodeT>, body: string, placeholders: [string, string][] = []) {
+        return newText({
+            body: [body.trim()],
+            path: this.#props.scopePath,
             context: props.commentDirectives.context,
             placeholders,
         })
@@ -205,15 +189,15 @@ export class MixedVisitor<
     #text(mod: LevelMod, props: VisitProps<MixNodeT>, trimOut: TrimOut, range: Range, nums: Nums): string {
         let [startWh, trimmed, endWh] = trimOut
         let { start, end } = range
-        const msg = this.#makeMsg(props, trimmed)
-        const heurMsgType = this.#props.checkHeuristic(msg)
+        const txt = this.#makeTxt(props, trimmed)
+        const heurMsgType = this.#props.checkHeuristic(txt)
         if (heurMsgType) {
-            msg.type = heurMsgType
+            txt.type = heurMsgType
             mod.hasTxtDesc = true
             mod.txts.push([
-                msg,
+                txt,
                 () => {
-                    const index = this.#props.index.get(getKey(msg.msgStr, msg.context))
+                    const index = this.#props.index.get(getKey(txt.body, txt.context))
                     this.#props.mstr.update(start + startWh, end - endWh, `{${this.#props.vars().rtTrans}(${index})}`)
                 },
             ])
@@ -256,17 +240,18 @@ export class MixedVisitor<
 
     #finalMod(
         props: VisitProps<MixNodeT>,
-        msg: Message,
+        txt: Text,
         lastChildEnd: number,
         childrenNestedRanges: [number, number, boolean][],
         hasExpr: boolean,
         nums: Nums,
     ): ModFunc {
         const vars = this.#props.vars()
+        const scope = this.#props.scopePath.at(-1)!
         return nested => {
-            const index = this.#props.index.get(getKey(msg.msgStr, msg.context))
+            const index = this.#props.index.get(getKey(txt.body, txt.context))
             if (
-                ((props.useComponent ?? true) && props.scope === 'markup' && hasExpr) ||
+                ((props.useComponent ?? true) && scope.type === 'element' && hasExpr) ||
                 childrenNestedRanges.length > 0
             ) {
                 if (nums.element + nums.text + nums.expr > 1) {
@@ -280,7 +265,7 @@ export class MixedVisitor<
             if (nested) {
                 begin += `${vars.rtTransCtx}(${vars.nestCtx}`
             } else {
-                if (msg.type === 'url') {
+                if (txt.type === 'url') {
                     begin += `${varNames.urlLocalize}(`
                     end = `), ${vars.rtLocale}${end}`
                 }
@@ -290,7 +275,7 @@ export class MixedVisitor<
                 begin += ', ['
                 end = `]${end}`
             }
-            if (props.scope === 'attribute' && `'"`.includes(this.#props.content[lastChildEnd]!)) {
+            if (scope.type === 'attribute' && `'"`.includes(this.#props.content[lastChildEnd]!)) {
                 const firstChild = props.children[0]!
                 const { start } = this.#props.getRange(firstChild)
                 this.#props.mstr.remove(start - 1, start)
@@ -301,27 +286,37 @@ export class MixedVisitor<
         }
     }
 
+    #getMod(scope: Scope, building: boolean, addFunc?: ModFunc) {
+        let mod = this.#mod.get(scope.type)
+        if (!mod) {
+            mod = newMod()
+            this.#mod.set(scope.type, mod)
+        }
+        if (addFunc) {
+            mod.funcs.push(addFunc)
+        }
+        mod.building ||= building
+        return mod
+    }
+
     visit(props: VisitProps<MixNodeT>) {
         if (props.children.length === 0) {
             return []
         }
         let hasCommentDirectives = false
-        let msgStr = ''
+        let body = ''
         let iArg = 0
         let iTag = 0
         const commentDirectivesOrig: CommentDirectives = { ...props.commentDirectives }
         let lastVisitIsComment = false
         const lastChildEnd = this.#getLastChildEnd(props.children)
         const childrenNestedRanges: NestedRanges = []
-        const msgs: Message[] = []
+        const txts: Text[] = []
         const placeholders: [string, string][] = []
         const alreadyInsideUnit = props.commentDirectives.unit ?? false
-        const mod = this.#mod[props.scope]
+        const scope = this.#props.scopePath.at(-1)!
         const nums = this.#childNums(props.children)
-        mod.building ||= alreadyInsideUnit || nums.text > 0
-        if (props.addMod) {
-            mod.funcs.push(props.addMod)
-        }
+        const mod = this.#getMod(scope, alreadyInsideUnit || nums.text > 0, props.addMod)
         const exprFuncs: ModFunc[] = []
         for (const child of props.children) {
             if (this.#props.isComment(child)) {
@@ -340,23 +335,23 @@ export class MixedVisitor<
             if (this.#props.isText(child)) {
                 const trimOut = trimText(this.#props.getTextContent(child))
                 const [startWh, trimmed] = trimOut
-                if ((startWh || trimmed === '') && !msgStr.endsWith(' ')) {
-                    msgStr += ' '
+                if ((startWh || trimmed === '') && !body.endsWith(' ')) {
+                    body += ' '
                 }
                 if (!trimmed) {
                     // whitespace
                     continue
                 }
                 if (props.commentDirectives.forceType !== false) {
-                    msgStr += this.#text(mod, props, trimOut, chRange, nums)
+                    body += this.#text(mod, props, trimOut, chRange, nums)
                 }
             } else if (props.commentDirectives.forceType !== false) {
                 if (this.#props.leaveInPlace(child)) {
-                    msgs.push(...this.#props.visitFunc(child))
+                    txts.push(...this.#props.visitFunc(child))
                 } else if (this.#props.isExpression(child)) {
-                    msgs.push(...this.#props.visitFunc(child))
+                    txts.push(...this.#props.visitFunc(child))
                     if (nums.text > 0 || nums.element > 0) {
-                        msgStr += this.#expression(exprFuncs, chRange, iArg, placeholders, lastChildEnd)
+                        body += this.#expression(exprFuncs, chRange, iArg, placeholders, lastChildEnd)
                         iArg++
                     }
                 } else {
@@ -365,27 +360,27 @@ export class MixedVisitor<
                         props.nestable && mod.building,
                         !alreadyInsideUnit && props.commentDirectives.unit,
                     )
-                    this.#mod[props.scope] = childMod
-                    msgs.push(...this.#props.visitFunc(child))
-                    this.#mod[props.scope] = mod
+                    this.#mod.set(scope.type, childMod)
+                    txts.push(...this.#props.visitFunc(child))
+                    this.#mod.set(scope.type, mod)
                     mod.children.push(childMod)
                     let nestedNeedsCtx = false
                     let chTxt = `<${iTag}/>`
                     mod.hasTxtDesc ||= childMod.hasTxtDesc
-                    if (childMod.pending && childMod.msg) {
+                    if (childMod.pending && childMod.txt) {
                         if (nums.element === 1 && nums.expr === 0 && nums.text === 0) {
-                            chTxt = childMod.msg.msgStr[0]!
-                            placeholders.push(...childMod.msg.placeholders)
+                            chTxt = childMod.txt.body[0]!
+                            placeholders.push(...childMod.txt.placeholders)
                         } else if (childMod.hasTxtDesc) {
-                            chTxt = `<${iTag}>${childMod.msg.msgStr[0]!}</${iTag}>`
-                            for (const [num, cont] of childMod.msg.placeholders) {
+                            chTxt = `<${iTag}>${childMod.txt.body[0]!}</${iTag}>`
+                            for (const [num, cont] of childMod.txt.placeholders) {
                                 placeholders.push([`${iTag}.${num}`, cont])
                             }
                             nestedNeedsCtx = true
                         }
                     }
                     childrenNestedRanges.push([chRange.start, chRange.end, nestedNeedsCtx])
-                    msgStr += chTxt
+                    body += chTxt
                     iTag++
                 }
             }
@@ -395,16 +390,16 @@ export class MixedVisitor<
             restoreCommentDirectives(props.commentDirectives, commentDirectivesOrig)
             lastVisitIsComment = false
         }
-        const msg = this.#makeMsg(props, msgStr, placeholders)
+        const txt = this.#makeTxt(props, body, placeholders)
         if (mod.hasTxtDesc) {
             if (!hasCommentDirectives) {
-                mod.msg = msg // can be taken together, and lvlHasMsg
+                mod.txt = txt // can be taken together, and lvlHasMsg
             }
-            mod.funcs.push(...exprFuncs, this.#finalMod(props, msg, lastChildEnd, childrenNestedRanges, iArg > 0, nums))
+            mod.funcs.push(...exprFuncs, this.#finalMod(props, txt, lastChildEnd, childrenNestedRanges, iArg > 0, nums))
         }
         if (mod.unit || !mod.building || hasCommentDirectives || !props.nestable) {
-            msgs.push(...this.applyMod(props.scope))
+            txts.push(...this.#applyModClear(scope.type))
         }
-        return msgs
+        return txts
     }
 }

--- a/packages/wuchale/src/adapter-vanilla/index.ts
+++ b/packages/wuchale/src/adapter-vanilla/index.ts
@@ -1,6 +1,6 @@
 // $$ cd .. && npm run test
 
-import { loaderPathResolver } from '../adapter-utils/index.js'
+import { getFuncNameNested, loaderPathResolver } from '../adapter-utils/index.js'
 import type { Adapter, AdapterArgs, CodePattern, LoaderChoice } from '../adapters.js'
 import { type DeepPartial, fillDefaults } from '../config.js'
 import { pofile } from '../pofile.js'
@@ -31,7 +31,7 @@ export const defaultArgs: VanillaArgs = {
     },
     loader: 'vite',
     runtime: {
-        initReactive: ({ nested }) => (nested ? null : false),
+        initReactive: path => (getFuncNameNested(path)[1] ? null : false),
         useReactive: false,
         plain: {
             wrapInit: expr => expr,

--- a/packages/wuchale/src/adapter-vanilla/index.ts
+++ b/packages/wuchale/src/adapter-vanilla/index.ts
@@ -2,9 +2,9 @@
 
 import { loaderPathResolver } from '../adapter-utils/index.js'
 import type { Adapter, AdapterArgs, CodePattern, LoaderChoice } from '../adapters.js'
-import { defaultHeuristicFuncOnly } from '../adapters.js'
 import { type DeepPartial, fillDefaults } from '../config.js'
 import { pofile } from '../pofile.js'
+import { defaultHeuristicFuncOnly } from '../text.js'
 import { Transformer } from './transformer.js'
 
 export { parseScript, scriptParseOptions, scriptParseOptionsWithComments } from './transformer.js'

--- a/packages/wuchale/src/adapter-vanilla/inertvisitors.ts
+++ b/packages/wuchale/src/adapter-vanilla/inertvisitors.ts
@@ -1,88 +1,88 @@
-import type { Message } from '../adapters.js'
+import type { Text } from '../text.js'
 
 export default class {
-    visitEmptyStatement(): Message[] {
+    visitEmptyStatement(): Text[] {
         return []
     }
-    visitArrayPattern(): Message[] {
+    visitArrayPattern(): Text[] {
         return []
     }
-    visitBreakStatement(): Message[] {
+    visitBreakStatement(): Text[] {
         return []
     }
-    visitCatchClause(): Message[] {
+    visitCatchClause(): Text[] {
         return []
     }
-    visitClassBody(): Message[] {
+    visitClassBody(): Text[] {
         return []
     }
-    visitClassExpression(): Message[] {
+    visitClassExpression(): Text[] {
         return []
     }
-    visitContinueStatement(): Message[] {
+    visitContinueStatement(): Text[] {
         return []
     }
-    visitDebuggerStatement(): Message[] {
+    visitDebuggerStatement(): Text[] {
         return []
     }
-    visitExportAllDeclaration(): Message[] {
+    visitExportAllDeclaration(): Text[] {
         return []
     }
-    visitExportSpecifier(): Message[] {
+    visitExportSpecifier(): Text[] {
         return []
     }
-    visitIdentifier(): Message[] {
+    visitIdentifier(): Text[] {
         return []
     }
-    visitImportAttribute(): Message[] {
+    visitImportAttribute(): Text[] {
         return []
     }
-    visitImportDeclaration(): Message[] {
+    visitImportDeclaration(): Text[] {
         return []
     }
-    visitImportDefaultSpecifier(): Message[] {
+    visitImportDefaultSpecifier(): Text[] {
         return []
     }
-    visitImportExpression(): Message[] {
+    visitImportExpression(): Text[] {
         return []
     }
-    visitImportNamespaceSpecifier(): Message[] {
+    visitImportNamespaceSpecifier(): Text[] {
         return []
     }
-    visitImportSpecifier(): Message[] {
+    visitImportSpecifier(): Text[] {
         return []
     }
-    visitMetaProperty(): Message[] {
+    visitMetaProperty(): Text[] {
         return []
     }
-    visitMethodDefinition(): Message[] {
+    visitMethodDefinition(): Text[] {
         return []
     } // handled inside visitClassDeclaration
-    visitPrivateIdentifier(): Message[] {
+    visitPrivateIdentifier(): Text[] {
         return []
     }
-    visitPropertyDefinition(): Message[] {
+    visitPropertyDefinition(): Text[] {
         return []
     }
-    visitStaticBlock(): Message[] {
+    visitStaticBlock(): Text[] {
         return []
     } // handled inside visitClassDeclaration
-    visitSuper(): Message[] {
+    visitSuper(): Text[] {
         return []
     }
-    visitTemplateElement(): Message[] {
+    visitTemplateElement(): Text[] {
         return []
     }
-    visitThisExpression(): Message[] {
+    visitThisExpression(): Text[] {
         return []
     }
-    visitThrowStatement(): Message[] {
+    visitThrowStatement(): Text[] {
         return []
     }
-    visitUpdateExpression(): Message[] {
+    visitUpdateExpression(): Text[] {
         return []
     }
-    visitWithStatement(): Message[] {
+    visitWithStatement(): Text[] {
         return []
     }
 }

--- a/packages/wuchale/src/adapter-vanilla/transformer.test.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.test.ts
@@ -1,12 +1,13 @@
 // $ node --import ../../testing/resolve.ts %f
 
-import { type TestContext, test } from 'node:test'
+import { test } from 'node:test'
 // @ts-expect-error
 import { transformTest, ts } from '../../testing/utils.ts'
+import { getFuncNameNested } from '../adapter-utils/index.js'
 import { IndexTracker, type RuntimeConf } from '../adapters.js'
 import { URLHandler } from '../handler/url.js'
 import { defaultArgs } from './index.js'
-import { decideRTDetails, Transformer } from './transformer.js'
+import { Transformer } from './transformer.js'
 
 const catalogExpr = { plain: '_w_load_()', reactive: '_w_load_rx_()' }
 const filename = 'test.ts'
@@ -22,27 +23,6 @@ const makeCtx = (content: string, index = new IndexTracker(true)) => ({
 
 const getOutput = (content: string, patterns = defaultArgs.patterns) =>
     new Transformer(makeCtx(content), defaultArgs.heuristic, patterns, defaultArgs.runtime).transform()
-
-test('RT details', (t: TestContext) => {
-    t.assert.deepStrictEqual(
-        decideRTDetails(
-            [
-                { type: 'function', name: 'foo' },
-                { type: 'assignment', left: false, targets: ['bar'] },
-                { type: 'funcexpr', kind: 'arrow' },
-            ],
-            'foo.ts',
-            {},
-        ),
-        { nested: true, file: 'foo.ts', ctx: {}, funcName: 'bar' },
-    )
-    t.assert.deepStrictEqual(decideRTDetails([{ type: 'function', name: 'foo' }], 'foo.ts', {}), {
-        nested: false,
-        file: 'foo.ts',
-        ctx: {},
-        funcName: 'foo',
-    })
-})
 
 test('Simple expression and assignment', t => {
     transformTest(
@@ -229,7 +209,7 @@ test('useReactive nullish fallback stays boolean', t => {
             defaultArgs.patterns,
             {
                 initReactive: () => false,
-                useReactive: ({ funcName }) => (funcName == null ? false : undefined),
+                useReactive: path => (getFuncNameNested(path)[0] == null ? false : undefined),
                 plain: {
                     wrapInit: expr => expr,
                     wrapUse: expr => `plainUse(${expr})`,

--- a/packages/wuchale/src/adapter-vanilla/transformer.test.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.test.ts
@@ -1,12 +1,12 @@
 // $ node --import ../../testing/resolve.ts %f
 
-import { test } from 'node:test'
+import { type TestContext, test } from 'node:test'
 // @ts-expect-error
 import { transformTest, ts } from '../../testing/utils.ts'
 import { IndexTracker, type RuntimeConf } from '../adapters.js'
 import { URLHandler } from '../handler/url.js'
 import { defaultArgs } from './index.js'
-import { Transformer } from './transformer.js'
+import { decideRTDetails, Transformer } from './transformer.js'
 
 const catalogExpr = { plain: '_w_load_()', reactive: '_w_load_rx_()' }
 const filename = 'test.ts'
@@ -22,6 +22,27 @@ const makeCtx = (content: string, index = new IndexTracker(true)) => ({
 
 const getOutput = (content: string, patterns = defaultArgs.patterns) =>
     new Transformer(makeCtx(content), defaultArgs.heuristic, patterns, defaultArgs.runtime).transform()
+
+test('RT details', (t: TestContext) => {
+    t.assert.deepStrictEqual(
+        decideRTDetails(
+            [
+                { type: 'function', name: 'foo' },
+                { type: 'assignment', left: false, targets: ['bar'] },
+                { type: 'funcexpr', kind: 'arrow' },
+            ],
+            'foo.ts',
+            {},
+        ),
+        { nested: true, file: 'foo.ts', ctx: {}, funcName: 'bar' },
+    )
+    t.assert.deepStrictEqual(decideRTDetails([{ type: 'function', name: 'foo' }], 'foo.ts', {}), {
+        nested: false,
+        file: 'foo.ts',
+        ctx: {},
+        funcName: 'foo',
+    })
+})
 
 test('Simple expression and assignment', t => {
     transformTest(
@@ -277,7 +298,7 @@ test('Plural and patterns', t => {
                 ] && bar(_w_runtime_(1))
             }
     `,
-        [{ msgStr: ['One item', '# items'] }, 'Hello'],
+        [{ body: ['One item', '# items'] }, 'Hello'],
     )
 })
 

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -12,18 +12,10 @@ import {
     updateCommentDirectives,
     varNames,
 } from '../adapter-utils/index.js'
-import type {
-    CodePattern,
-    DecideReactiveDetails,
-    IndexTracker,
-    RuntimeConf,
-    TransformCtx,
-    TransformOutput,
-    UrlMatcher,
-} from '../adapters.js'
+import type { CodePattern, IndexTracker, RuntimeConf, TransformCtx, TransformOutput, UrlMatcher } from '../adapters.js'
 import { getKey } from '../adapters.js'
 import type { HeuristicFunc, HeuristicResultChecked, Scope, TextType } from '../text.js'
-import { ascendPath, defaultHeuristicFuncOnly, newText, type Text } from '../text.js'
+import { defaultHeuristicFuncOnly, newText, type Text } from '../text.js'
 import InertVisitors from './inertvisitors.js'
 
 export const scriptParseOptions: Estree.Options = {
@@ -72,41 +64,6 @@ export function parseScript(content: string): [Estree.Program, Estree.Comment[][
 
 type InitRuntimeFunc = (funcName?: string, parentFunc?: string) => string | undefined
 
-export function decideRTDetails<R>(path: Scope[], file: string, ctx: R) {
-    const details: DecideReactiveDetails<R> = {
-        file,
-        ctx,
-        nested: false,
-    }
-    let innerIsArrow = false
-    for (const s of ascendPath(path)) {
-        if (s.type === 'funcexpr') {
-            innerIsArrow = true
-            continue
-        }
-        let funcName: string | null = null
-        if (s.type === 'function') {
-            funcName = s.name
-        } else if (innerIsArrow) {
-            if (s.type === 'assignment' && !s.left && s.targets.length === 1) {
-                funcName = s.targets[0]!
-            } else {
-                funcName = ''
-            }
-        }
-        innerIsArrow = false
-        if (funcName === null) {
-            continue
-        }
-        if (details.funcName) {
-            details.nested = true
-            return details
-        }
-        details.funcName = funcName
-    }
-    return details
-}
-
 export class Transformer extends InertVisitors {
     index: IndexTracker
     heuristic: HeuristicFunc
@@ -149,7 +106,7 @@ export class Transformer extends InertVisitors {
         const topLevelUseReactive =
             typeof rtConf.useReactive === 'boolean'
                 ? rtConf.useReactive
-                : (rtConf.useReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx)) ?? false)
+                : (rtConf.useReactive(this.scopePath, ctx.filename, this.runtimeCtx) ?? false)
 
         const vars: Record<string, { [key in 'plain' | 'reactive']: RuntimeVars }> = {}
         // to enable the use of different runtime vars for different places, right now for svelte <script module>s
@@ -164,12 +121,11 @@ export class Transformer extends InertVisitors {
             const useReactive =
                 typeof rtConf.useReactive === 'boolean'
                     ? rtConf.useReactive
-                    : (rtConf.useReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx)) ??
-                      topLevelUseReactive)
+                    : (rtConf.useReactive(this.scopePath, ctx.filename, this.runtimeCtx) ?? topLevelUseReactive)
             const currentVars = vars[this.currentRtVar]!
             return useReactive ? currentVars.reactive : currentVars.plain
         }
-        this.initReactive = () => rtConf.initReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx))
+        this.initReactive = () => rtConf.initReactive(this.scopePath, ctx.filename, this.runtimeCtx)
         this.initRuntime = () => {
             let initReactive = this.initReactive()
             if (initReactive == null) {

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -14,18 +14,16 @@ import {
 } from '../adapter-utils/index.js'
 import type {
     CodePattern,
-    HeuristicDetails,
-    HeuristicDetailsBase,
-    HeuristicFunc,
-    HeuristicResultChecked,
+    DecideReactiveDetails,
     IndexTracker,
-    MessageType,
     RuntimeConf,
     TransformCtx,
     TransformOutput,
     UrlMatcher,
 } from '../adapters.js'
-import { defaultHeuristicFuncOnly, getKey, type Message, newMessage } from '../adapters.js'
+import { getKey } from '../adapters.js'
+import type { HeuristicFunc, HeuristicResultChecked, Scope, TextType } from '../text.js'
+import { ascendPath, defaultHeuristicFuncOnly, newText, type Text } from '../text.js'
 import InertVisitors from './inertvisitors.js'
 
 export const scriptParseOptions: Estree.Options = {
@@ -74,12 +72,40 @@ export function parseScript(content: string): [Estree.Program, Estree.Comment[][
 
 type InitRuntimeFunc = (funcName?: string, parentFunc?: string) => string | undefined
 
-const extendPropDownTypes: Estree.Property['value']['type'][] = [
-    'Literal',
-    'TemplateLiteral',
-    'TaggedTemplateExpression',
-    'ObjectExpression',
-]
+export function decideRTDetails<R>(path: Scope[], file: string, ctx: R) {
+    const details: DecideReactiveDetails<R> = {
+        file,
+        ctx,
+        nested: false,
+    }
+    let innerIsArrow = false
+    for (const s of ascendPath(path)) {
+        if (s.type === 'funcexpr') {
+            innerIsArrow = true
+            continue
+        }
+        let funcName: string | null = null
+        if (s.type === 'function') {
+            funcName = s.name
+        } else if (innerIsArrow) {
+            if (s.type === 'assignment' && !s.left && s.targets.length === 1) {
+                funcName = s.targets[0]!
+            } else {
+                funcName = ''
+            }
+        }
+        innerIsArrow = false
+        if (funcName === null) {
+            continue
+        }
+        if (details.funcName) {
+            details.nested = true
+            return details
+        }
+        details.funcName = funcName
+    }
+    return details
+}
 
 export class Transformer extends InertVisitors {
     index: IndexTracker
@@ -90,14 +116,15 @@ export class Transformer extends InertVisitors {
     mstr: MagicString
     patterns: CodePattern[]
     matchUrl: UrlMatcher
-    initReactive: (...a: Parameters<InitRuntimeFunc>) => ReturnType<RuntimeConf['initReactive']>
+    initReactive: () => ReturnType<RuntimeConf['initReactive']>
     initRuntime: InitRuntimeFunc
     currentRtVar: string
     vars: () => RuntimeVars
 
     // state
     commentDirectives: CommentDirectives = {}
-    heuristciDetails: HeuristicDetails = { file: '', scope: 'script', insideProgram: true }
+    filename: string
+    scopePath: Scope[] = []
     /** .start of the first statements in their respective parents, to put the runtime init before */
     realBodyStarts = new Set<number>()
     patternMatchMods = 0 // for realBodyStarts
@@ -115,19 +142,14 @@ export class Transformer extends InertVisitors {
         this.index = ctx.index
         this.content = ctx.content
         this.matchUrl = ctx.matchUrl
-        this.heuristciDetails.file = ctx.filename
+        this.filename = ctx.filename
         this.heuristic = heuristic
         this.patterns = patterns
         this.mstr = new MagicString(this.content)
         const topLevelUseReactive =
             typeof rtConf.useReactive === 'boolean'
                 ? rtConf.useReactive
-                : (rtConf.useReactive({
-                      funcName: undefined,
-                      nested: false,
-                      file: ctx.filename,
-                      ctx: this.runtimeCtx,
-                  }) ?? false)
+                : (rtConf.useReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx)) ?? false)
 
         const vars: Record<string, { [key in 'plain' | 'reactive']: RuntimeVars }> = {}
         // to enable the use of different runtime vars for different places, right now for svelte <script module>s
@@ -142,24 +164,14 @@ export class Transformer extends InertVisitors {
             const useReactive =
                 typeof rtConf.useReactive === 'boolean'
                     ? rtConf.useReactive
-                    : (rtConf.useReactive({
-                          funcName: this.heuristciDetails.funcName ?? undefined,
-                          nested: this.heuristciDetails.funcIsNested ?? false,
-                          file: ctx.filename,
-                          ctx: this.runtimeCtx,
-                      }) ?? topLevelUseReactive)
+                    : (rtConf.useReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx)) ??
+                      topLevelUseReactive)
             const currentVars = vars[this.currentRtVar]!
             return useReactive ? currentVars.reactive : currentVars.plain
         }
-        this.initReactive = (funcName, parentFunc) =>
-            rtConf.initReactive({
-                funcName,
-                nested: parentFunc != null,
-                file: ctx.filename,
-                ctx: this.runtimeCtx,
-            })
-        this.initRuntime = (funcName, parentFunc) => {
-            let initReactive = this.initReactive(funcName, parentFunc)
+        this.initReactive = () => rtConf.initReactive(decideRTDetails(this.scopePath, ctx.filename, this.runtimeCtx))
+        this.initRuntime = () => {
+            let initReactive = this.initReactive()
             if (initReactive == null) {
                 return
             }
@@ -172,64 +184,68 @@ export class Transformer extends InertVisitors {
         }
     }
 
-    fullHeuristicDetails(detailsBase: HeuristicDetailsBase): HeuristicDetails {
-        return {
-            ...this.heuristciDetails,
-            ...detailsBase,
-        }
-    }
-
-    getHeuristicMessageType(msg: Message): HeuristicResultChecked {
-        const msgStr = msg.msgStr.join('\n')
-        if (!msgStr) {
+    getHeuristicMessageType(txt: Text): HeuristicResultChecked {
+        const body0 = txt.body[0]
+        if (!body0) {
             // nothing to ask
             return false
         }
         if (this.commentDirectives.forceType === false) {
             return false
         }
-        const heuRes = this.heuristic(msg) ?? defaultHeuristicFuncOnly(msg) ?? 'message'
-        if (this.commentDirectives.forceType == null && heuRes === 'url' && this.matchUrl(msgStr) == null) {
+        const heuRes = this.heuristic(txt, this.filename) ?? defaultHeuristicFuncOnly(txt, this.filename) ?? 'message'
+        if (this.commentDirectives.forceType == null && heuRes === 'url' && this.matchUrl(body0) == null) {
             return false
         }
         return this.commentDirectives.forceType || heuRes
     }
 
-    checkHeuristicAllowNew(msgStr: string, detailsBase: HeuristicDetailsBase): [MessageType, Message] | [false, null] {
-        if (!msgStr) {
+    checkHeuristicAllowNew(body: string): [TextType, Text] | [false, null] {
+        if (!body) {
             // nothing to ask
             return [false, null]
         }
-        const msg = newMessage({
-            msgStr: [msgStr],
-            details: this.fullHeuristicDetails(detailsBase),
+        const txt = newText({
+            body: [body],
+            path: this.scopePath,
             context: this.commentDirectives.context,
         })
-        const heuRes = this.getHeuristicMessageType(msg)
-        // not allowed here, or msg is new but new msgs are not allowed
-        if (!heuRes || !this.index.has(getKey(msg.msgStr, msg.context))) {
+        const heuRes = this.getHeuristicMessageType(txt)
+        // not allowed here, or txt is new but new txts are not allowed
+        if (!heuRes || !this.index.has(getKey(txt.body, txt.context))) {
             return [false, null]
         }
-        msg.type = heuRes
-        return [heuRes, msg]
+        txt.type = heuRes
+        return [heuRes, txt]
     }
 
-    literalRepl(msgInfo: Message) {
+    inScope<T>(scope: Scope, fn: () => T) {
+        this.scopePath.push(scope)
+        const ret = fn()
+        this.scopePath.pop()
+        return ret
+    }
+
+    inScopeVisit(scope: Scope, node: Estree.AnyNode): Text[] {
+        return this.inScope(scope, () => this.visit(node))
+    }
+
+    literalRepl(txt: Text) {
         const vars = this.vars()
-        const indexKey = getKey(msgInfo.msgStr, msgInfo.context)
+        const indexKey = getKey(txt.body, txt.context)
         const repl = `${vars.rtTrans}(${this.index.get(indexKey)})`
-        if (msgInfo.type !== 'url') {
+        if (txt.type !== 'url') {
             return repl
         }
         return `${varNames.urlLocalize}(${repl}, ${vars.rtLocale})`
     }
 
-    visitLiteral(node: Estree.Literal, heuristicDetailsBase?: HeuristicDetailsBase): Message[] {
+    visitLiteral(node: Estree.Literal): Text[] {
         if (typeof node.value !== 'string') {
             return []
         }
         const { start, end } = node
-        const [pass, msgInfo] = this.checkHeuristicAllowNew(node.value, heuristicDetailsBase ?? { scope: 'script' })
+        const [pass, msgInfo] = this.checkHeuristicAllowNew(node.value)
         if (!pass) {
             return []
         }
@@ -237,28 +253,28 @@ export class Transformer extends InertVisitors {
         return [msgInfo]
     }
 
-    visitArrayExpression(node: Estree.ArrayExpression): Message[] {
+    visitArrayExpression(node: Estree.ArrayExpression): Text[] {
         return node.elements.flatMap(elm => (elm ? this.visit(elm) : []))
     }
 
-    visitSequenceExpression(node: Estree.SequenceExpression): Message[] {
+    visitSequenceExpression(node: Estree.SequenceExpression): Text[] {
         return node.expressions.flatMap(n => this.visit(n))
     }
 
-    visitObjectExpression(node: Estree.ObjectExpression): Message[] {
+    visitObjectExpression(node: Estree.ObjectExpression): Text[] {
         return node.properties.flatMap(n => this.visit(n))
     }
 
-    visitObjectPattern(node: Estree.ObjectPattern): Message[] {
+    visitObjectPattern(node: Estree.ObjectPattern): Text[] {
         return node.properties.flatMap(n => this.visit(n))
     }
 
-    visitRestElement(node: Estree.RestElement): Message[] {
+    visitRestElement(node: Estree.RestElement): Text[] {
         return this.visit(node.argument)
     }
 
-    visitProperty(node: Estree.Property): Message[] {
-        const msgs = this.visit(node.key)
+    visitProperty(node: Estree.Property): Text[] {
+        const txts = this.visit(node.key)
         let keyName = '[]'
         let keyIsLiteral = false
         if (node.key.type === 'Identifier') {
@@ -267,50 +283,43 @@ export class Transformer extends InertVisitors {
             keyIsLiteral = true
             keyName = node.key.value
         }
-        if (msgs.length && keyIsLiteral && !node.computed) {
+        if (txts.length && keyIsLiteral && !node.computed) {
             this.mstr.appendRight(node.key.start, '[')
             this.mstr.appendLeft(node.key.end, ']')
         }
-        const extendPropDown = extendPropDownTypes.includes(node.value.type)
-        const prevProp = this.heuristciDetails.property
-        if (extendPropDown) {
-            this.heuristciDetails.property = prevProp ? `${prevProp}.${keyName}` : keyName
-        }
-        msgs.push(...this.visit(node.value))
-        if (extendPropDown) {
-            this.heuristciDetails.property = prevProp // restore
-        }
-        return msgs
+        txts.push(...this.inScopeVisit({ type: 'property', name: keyName }, node.value))
+        return txts
     }
 
-    visitSpreadElement(node: Estree.SpreadElement): Message[] {
+    visitSpreadElement(node: Estree.SpreadElement): Text[] {
         return this.visit(node.argument)
     }
 
-    visitMemberExpression(node: Estree.MemberExpression): Message[] {
+    visitMemberExpression(node: Estree.MemberExpression): Text[] {
         return [...this.visit(node.object), ...this.visit(node.property)]
     }
 
-    visitChainExpression(node: Estree.ChainExpression): Message[] {
+    visitChainExpression(node: Estree.ChainExpression): Text[] {
         return this.visit(node.expression)
     }
 
-    visitNewExpression(node: Estree.NewExpression): Message[] {
-        return node.arguments.flatMap(n => this.visit(n))
+    visitNewExpression(node: Estree.NewExpression): Text[] {
+        return this.inScope({ type: 'call', kind: 'new', name: this.getCalleeName(node.callee) }, () =>
+            node.arguments.flatMap(n => this.visit(n)),
+        )
     }
 
-    defaultVisitCallExpression(node: Estree.CallExpression): Message[] {
-        const msgs = this.visit(node.callee)
-        const currentCall = this.heuristciDetails.call
-        this.heuristciDetails.call = this.getCalleeName(node.callee)
-        for (const arg of node.arguments) {
-            msgs.push(...this.visit(arg))
-        }
-        this.heuristciDetails.call = currentCall // restore
-        return msgs
+    defaultVisitCallExpression(node: Estree.CallExpression): Text[] {
+        const txts = this.visit(node.callee)
+        this.inScope({ type: 'call', kind: 'function', name: this.getCalleeName(node.callee) }, () => {
+            for (const arg of node.arguments) {
+                txts.push(...this.visit(arg))
+            }
+        })
+        return txts
     }
 
-    visitCallExpression(node: Estree.CallExpression): Message[] {
+    visitCallExpression(node: Estree.CallExpression): Text[] {
         if (node.callee.type !== 'Identifier') {
             return this.defaultVisitCallExpression(node)
         }
@@ -325,7 +334,7 @@ export class Transformer extends InertVisitors {
                 break
             }
         }
-        const msgs: Message[] = []
+        const txts: Text[] = []
         const updates: [number, number, string][] = []
         const appends: [number, string][] = []
         let lastArgEnd: number | null = null
@@ -374,17 +383,17 @@ export class Transformer extends InertVisitors {
                 if (typeof argVal.value !== 'string') {
                     return this.defaultVisitCallExpression(node)
                 }
-                const msgInfo = newMessage({
-                    msgStr: [argVal.value],
-                    details: this.fullHeuristicDetails({ scope: 'script' }),
+                const msgInfo = newText({
+                    body: [argVal.value],
+                    path: this.scopePath,
                     context: this.commentDirectives.context,
                 })
                 updates.push([argVal.start, argVal.end, this.literalRepl(msgInfo)])
-                msgs.push(msgInfo)
+                txts.push(msgInfo)
                 continue
             }
             if (argVal.type === 'TemplateLiteral') {
-                msgs.push(...this.visitTemplateLiteral(argVal, true))
+                txts.push(...this.visitTemplateLiteral(argVal, true))
                 continue
             }
             if (argVal.type !== 'ArrayExpression') {
@@ -398,13 +407,13 @@ export class Transformer extends InertVisitors {
                 candidates.push(elm.value)
             }
             // plural(num, ['Form one', 'Form two'])
-            const msgInfo = newMessage({
-                msgStr: candidates,
-                details: this.fullHeuristicDetails({ scope: 'script' }),
+            const txt = newText({
+                body: candidates,
+                path: this.scopePath,
                 context: this.commentDirectives.context,
             })
-            const index = this.index.get(getKey(msgInfo.msgStr, msgInfo.context))
-            msgs.push(msgInfo)
+            const index = this.index.get(getKey(txt.body, txt.context))
+            txts.push(txt)
             updates.push([argVal.start, argVal.end, `${this.vars().rtTPlural}(${index})`])
         }
         for (const [start, end, by] of updates) {
@@ -415,26 +424,26 @@ export class Transformer extends InertVisitors {
             this.mstr.appendRight(index, insert)
             this.patternMatchMods++
         }
-        return msgs
+        return txts
     }
 
-    visitBinaryExpression(node: Estree.BinaryExpression): Message[] {
+    visitBinaryExpression(node: Estree.BinaryExpression): Text[] {
         return [...this.visit(node.left), ...this.visit(node.right)]
     }
 
-    visitConditionalExpression(node: Estree.ConditionalExpression): Message[] {
+    visitConditionalExpression(node: Estree.ConditionalExpression): Text[] {
         return [...this.visit(node.test), ...this.visit(node.consequent), ...this.visit(node.alternate)]
     }
 
-    visitUnaryExpression(node: Estree.UnaryExpression): Message[] {
+    visitUnaryExpression(node: Estree.UnaryExpression): Text[] {
         return this.visit(node.argument)
     }
 
-    visitLogicalExpression(node: Estree.LogicalExpression): Message[] {
+    visitLogicalExpression(node: Estree.LogicalExpression): Text[] {
         return [...this.visit(node.left), ...this.visit(node.right)]
     }
 
-    visitAwaitExpression(node: Estree.AwaitExpression): Message[] {
+    visitAwaitExpression(node: Estree.AwaitExpression): Text[] {
         return this.visit(node.argument)
     }
 
@@ -442,30 +451,30 @@ export class Transformer extends InertVisitors {
         return [...this.visit(node.left), ...this.visit(node.right)]
     }
 
-    visitAssignmentPattern(node: Estree.AssignmentPattern): Message[] {
+    visitAssignmentPattern(node: Estree.AssignmentPattern): Text[] {
         return [...this.visit(node.left), ...this.visit(node.right)]
     }
 
-    visitForOfStatement(node: Estree.ForOfStatement): Message[] {
+    visitForOfStatement(node: Estree.ForOfStatement): Text[] {
         return [...this.visit(node.left), ...this.visit(node.right), ...this.visit(node.body)]
     }
 
-    visitForInStatement(node: Estree.ForInStatement): Message[] {
+    visitForInStatement(node: Estree.ForInStatement): Text[] {
         return [...this.visit(node.left), ...this.visit(node.right), ...this.visit(node.body)]
     }
 
-    visitForStatement(node: Estree.ForStatement): Message[] {
-        const msgs = this.visit(node.body)
+    visitForStatement(node: Estree.ForStatement): Text[] {
+        const txts = this.visit(node.body)
         if (node.init) {
-            msgs.push(...this.visit(node.init))
+            txts.push(...this.visit(node.init))
         }
         if (node.test) {
-            msgs.push(...this.visit(node.test))
+            txts.push(...this.visit(node.test))
         }
         if (node.update) {
-            msgs.push(...this.visit(node.update))
+            txts.push(...this.visit(node.update))
         }
-        return msgs
+        return txts
     }
 
     getMemberChainName(node: Estree.MemberExpression): string {
@@ -498,83 +507,54 @@ export class Transformer extends InertVisitors {
         return `[${callee.type}]`
     }
 
-    getActualExpression(expr?: Estree.Expression | Estree.TSAsExpression | Estree.TSTypeAssertion) {
-        if (!expr) {
-            return null
-        }
-        if (expr.type === 'TSAsExpression' || expr.type === 'TSTypeAssertion') {
-            return expr.expression
-        }
-        return expr
+    visitExpressionStatement(node: Estree.ExpressionStatement): Text[] {
+        return this.inScopeVisit({ type: 'expression' }, node.expression)
     }
 
-    withUpdateTLDetails(visit: (atTopLevel: boolean) => Message[]) {
-        const atTopLevelDefn = this.heuristciDetails.insideProgram && !this.heuristciDetails.declaring
-        const msgs = visit(atTopLevelDefn)
-        if (atTopLevelDefn) {
-            this.heuristciDetails.topLevelCall = undefined // reset
-            this.heuristciDetails.declaring = undefined
+    getAssignmentNames(id: Estree.Pattern | Estree.AssignmentProperty) {
+        let names: string[] = []
+        if (id.type === 'Identifier') {
+            names.push(id.name)
+        } else if (id.type === 'ArrayPattern') {
+            names = id.elements.filter(n => n !== null).flatMap(this.getAssignmentNames)
+        } else if (id.type === 'ObjectPattern') {
+            names = id.properties.flatMap(this.getAssignmentNames)
+        } else if (id.type === 'RestElement') {
+            names = this.getAssignmentNames(id.argument)
+        } else if (id.type === 'AssignmentPattern') {
+            names = this.getAssignmentNames(id.left)
         }
-        return msgs
-    }
-
-    visitExpressionStatement(node: Estree.ExpressionStatement): Message[] {
-        return this.withUpdateTLDetails(topLevel => {
-            const expr = this.getActualExpression(node.expression)!
-            if (topLevel) {
-                this.heuristciDetails.declaring = 'expression'
-                if (expr.type === 'CallExpression') {
-                    this.heuristciDetails.topLevelCall = this.getCalleeName(expr.callee)
-                }
-            }
-            return this.visit(expr)
-        })
+        return names
     }
 
     // for e.g. svelte to surrounded with $derived
     visitVariableDeclarator(node: Estree.VariableDeclarator) {
-        return this.withUpdateTLDetails(topLevel => {
-            if (!node.init) {
-                return []
-            }
-            const init = this.getActualExpression(node.init)!
-            if (topLevel) {
-                if (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression') {
-                    this.heuristciDetails.declaring = 'function'
-                } else {
-                    this.heuristciDetails.declaring = 'variable'
-                }
-            }
-            this.heuristciDetails.leftSide = true
-            const msgs = this.visit(node.id)
-            this.heuristciDetails.leftSide = false
-            if (topLevel && this.heuristciDetails.declaring === 'variable' && init.type === 'CallExpression') {
-                this.heuristciDetails.topLevelCall = this.getCalleeName(init.callee)
-            }
-            delete this.heuristciDetails.leftSide
-            if (
-                node.id.type === 'Identifier' &&
-                (init.type === 'ArrowFunctionExpression' || init.type === 'FunctionExpression')
-            ) {
-                return [...msgs, ...this.visitFunctionBody(init.body, node.id.name, init.end)]
-            }
-            return [...msgs, ...this.visit(node.init)]
-        })
+        if (!node.init) {
+            return []
+        }
+        const txts = this.inScopeVisit({ type: 'assignment', left: true }, node.id)
+        txts.push(
+            ...this.inScopeVisit(
+                { type: 'assignment', left: false, targets: this.getAssignmentNames(node.id) },
+                node.init,
+            ),
+        )
+        return txts
     }
 
-    visitVariableDeclaration(node: Estree.VariableDeclaration): Message[] {
+    visitVariableDeclaration(node: Estree.VariableDeclaration): Text[] {
         return node.declarations.flatMap(n => this.visitVariableDeclarator(n))
     }
 
-    visitExportNamedDeclaration(node: Estree.ExportNamedDeclaration | Estree.ExportDefaultDeclaration): Message[] {
-        this.heuristciDetails.exported = true
-        const msgs = node.declaration ? this.visit(node.declaration) : []
-        delete this.heuristciDetails.exported
-        return msgs
+    visitExportNamedDeclaration(node: Estree.ExportNamedDeclaration | Estree.ExportDefaultDeclaration): Text[] {
+        if (!node.declaration) {
+            return []
+        }
+        return this.inScopeVisit({ type: 'export' }, node.declaration)
     }
 
     visitExportDefaultDeclaration(node: Estree.ExportDefaultDeclaration) {
-        return this.visitExportNamedDeclaration(node)
+        return this.inScopeVisit({ type: 'export' }, node)
     }
 
     hasReturn(node: Estree.AnyNode | Estree.AnyNode[]): boolean {
@@ -607,19 +587,19 @@ export class Transformer extends InertVisitors {
         return bodyStart < newBodyStart ? bodyStart : newBodyStart
     }
 
-    visitStatementsNSaveRealBodyStart(nodes: (Estree.Statement | Estree.ModuleDeclaration)[]): Message[] {
+    visitStatementsNSaveRealBodyStart(nodes: (Estree.Statement | Estree.ModuleDeclaration)[]): Text[] {
         // the runtime should be initialized:
-        // - before any extracted messages and function pattern match modifications: to make it available
+        // - before any extracted txts and function pattern match modifications: to make it available
         // - before any return statement: to respect react hooks requirement of always calling the same
         // - after any function calls: to handle the case where one of them is loading the catalogs
         // - but before hoited function calls of the ones down below: to make it available at call time
-        const msgs: Message[] = []
+        const txts: Text[] = []
         let bodyStart: number | null = null
         const firstCalls = new Map<string, number>()
         for (const bod of nodes) {
             const prevPatternMods = this.patternMatchMods
-            const prevMsgsLen = msgs.length
-            msgs.push(...this.visit(bod))
+            const prevMsgsLen = txts.length
+            txts.push(...this.visit(bod))
             // get bodyStart
             if (bod.type === 'ExpressionStatement') {
                 if (bod.expression.type === 'CallExpression') {
@@ -637,14 +617,14 @@ export class Transformer extends InertVisitors {
                     }
                 }
             }
-            if (msgs.length > prevMsgsLen || this.patternMatchMods > prevPatternMods || this.hasReturn(bod)) {
+            if (txts.length > prevMsgsLen || this.patternMatchMods > prevPatternMods || this.hasReturn(bod)) {
                 bodyStart = this.#updateBodyStart(bodyStart, bod.start)
             }
         }
         if (bodyStart) {
             this.realBodyStarts.add(bodyStart)
         }
-        return msgs
+        return txts
     }
 
     getRealBodyStart(nodes: (Estree.Statement | Estree.ModuleDeclaration)[]): number | undefined {
@@ -664,15 +644,11 @@ export class Transformer extends InertVisitors {
         return nonLiteralStart ?? nodes[0]?.start
     }
 
-    visitFunctionBody(node: Estree.BlockStatement | Estree.Expression, name?: string, end?: number): Message[] {
-        const prevFuncDef = this.heuristciDetails.funcName
-        const prevFuncNested = this.heuristciDetails.funcIsNested
-        this.heuristciDetails.funcName = name
-        this.heuristciDetails.funcIsNested = name != null && prevFuncDef != null
+    visitFunctionBody(node: Estree.BlockStatement | Estree.Expression, end?: number): Text[] {
         const prevPatternMods = this.patternMatchMods
-        const msgs = this.visit(node)
-        if (msgs.length > 0 || this.patternMatchMods > prevPatternMods) {
-            const initRuntime = this.initRuntime(this.heuristciDetails.funcName, prevFuncDef ?? undefined)
+        const txts = this.visit(node)
+        if (txts.length > 0 || this.patternMatchMods > prevPatternMods) {
+            const initRuntime = this.initRuntime()
             if (initRuntime) {
                 if (node.type === 'BlockStatement') {
                     this.mstr.prependLeft(this.getRealBodyStart(node.body) ?? node.start, initRuntime)
@@ -694,112 +670,116 @@ export class Transformer extends InertVisitors {
                 }
             }
         }
-        this.heuristciDetails.funcIsNested = prevFuncNested
-        this.heuristciDetails.funcName = prevFuncDef
-        return msgs
+        return txts
     }
 
-    visitFunctionDeclaration(node: Estree.FunctionDeclaration): Message[] {
-        const declaring = this.heuristciDetails.declaring
-        this.heuristciDetails.declaring = 'function'
-        const msgs = this.visitFunctionBody(node.body, node.id?.name ?? '')
-        this.heuristciDetails.declaring = declaring
-        return msgs
+    visitFunctionDeclaration(node: Estree.FunctionDeclaration): Text[] {
+        return this.inScope({ type: 'function', name: node.id.name }, () => this.visitFunctionBody(node.body))
     }
 
-    visitArrowFunctionExpression(node: Estree.ArrowFunctionExpression): Message[] {
-        return this.visitFunctionBody(node.body, '', node.end)
+    visitArrowFunctionExpression(node: Estree.ArrowFunctionExpression | Estree.FunctionExpression): Text[] {
+        return this.inScope(
+            {
+                type: 'funcexpr',
+                kind: node.type === 'ArrowFunctionExpression' ? 'arrow' : 'function',
+            },
+            () => this.visitFunctionBody(node.body, node.end),
+        )
     }
 
-    visitFunctionExpression(node: Estree.FunctionExpression): Message[] {
-        return this.visitFunctionBody(node.body, '')
+    visitFunctionExpression(node: Estree.FunctionExpression): Text[] {
+        return this.visitArrowFunctionExpression(node)
     }
 
-    visitBlockStatement(node: Estree.BlockStatement): Message[] {
+    visitBlockStatement(node: Estree.BlockStatement): Text[] {
         return this.visitStatementsNSaveRealBodyStart(node.body)
     }
 
-    visitReturnStatement(node: Estree.ReturnStatement): Message[] {
+    visitReturnStatement(node: Estree.ReturnStatement): Text[] {
         return node.argument ? this.visit(node.argument) : []
     }
 
-    visitIfStatement(node: Estree.IfStatement): Message[] {
-        const msgs = this.visit(node.test)
-        msgs.push(...this.visit(node.consequent))
+    visitIfStatement(node: Estree.IfStatement): Text[] {
+        const txts = this.visit(node.test)
+        txts.push(...this.visit(node.consequent))
         if (node.alternate) {
-            msgs.push(...this.visit(node.alternate))
+            txts.push(...this.visit(node.alternate))
         }
-        return msgs
+        return txts
     }
 
-    visitWhileStatement(node: Estree.WhileStatement): Message[] {
+    visitWhileStatement(node: Estree.WhileStatement): Text[] {
         return [...this.visit(node.test), ...this.visit(node.body)]
     }
 
-    visitDoWhileStatement(node: Estree.DoWhileStatement): Message[] {
+    visitDoWhileStatement(node: Estree.DoWhileStatement): Text[] {
         return [...this.visit(node.body), ...this.visit(node.test)]
     }
 
-    visitLabeledStatement(node: Estree.LabeledStatement): Message[] {
+    visitLabeledStatement(node: Estree.LabeledStatement): Text[] {
         return this.visit(node.body)
     }
 
-    visitParenthesizedExpression(node: Estree.ParenthesizedExpression): Message[] {
+    visitParenthesizedExpression(node: Estree.ParenthesizedExpression): Text[] {
         return this.visit(node.expression)
     }
 
-    visitSwitchStatement(node: Estree.SwitchStatement): Message[] {
+    visitSwitchStatement(node: Estree.SwitchStatement): Text[] {
         return node.cases.flatMap(n => this.visit(n))
     }
 
-    visitSwitchCase(node: Estree.SwitchCase): Message[] {
-        const msgs = node.consequent.flatMap(n => this.visit(n))
+    visitSwitchCase(node: Estree.SwitchCase): Text[] {
+        const txts = node.consequent.flatMap(n => this.visit(n))
         if (node.test) {
-            return [...this.visit(node.test), ...msgs]
+            return [...this.visit(node.test), ...txts]
         }
-        return msgs
+        return txts
     }
 
-    visitYieldExpression(node: Estree.YieldExpression): Message[] {
+    visitYieldExpression(node: Estree.YieldExpression): Text[] {
         return node.argument ? this.visit(node.argument) : []
     }
 
-    visitClassDeclaration(node: Estree.ClassDeclaration): Message[] {
-        const msgs: Message[] = []
-        const prevDecl = this.heuristciDetails.declaring
-        this.heuristciDetails.declaring = 'class'
-        for (const body of node.body.body) {
-            if (body.type === 'MethodDefinition') {
-                msgs.push(...this.visit(body.key))
-                const methodName = this.content.slice(body.key.start, body.key.end)
-                if (body.value.type === 'FunctionExpression') {
-                    // and not e.g. TSDeclareMethod
-                    msgs.push(...this.visitFunctionBody(body.value.body, `${node.id.name}.${methodName}`))
+    visitClassDeclaration(node: Estree.ClassDeclaration): Text[] {
+        const txts: Text[] = []
+        this.inScope({ type: 'class', name: node.id.name }, () => {
+            for (const body of node.body.body) {
+                if (body.type === 'MethodDefinition') {
+                    const methodName = this.content.slice(body.key.start, body.key.end)
+                    txts.push(...this.visit(body.key))
+                    if (body.value.type === 'FunctionExpression') {
+                        // and not e.g. TSDeclareMethod
+                        txts.push(
+                            ...this.inScope({ type: 'method', name: methodName }, () =>
+                                this.visitFunctionBody(body.value.body),
+                            ),
+                        )
+                    }
+                } else if (body.type === 'StaticBlock') {
+                    txts.push(
+                        ...this.inScope({ type: 'method', name: '[static]' }, () =>
+                            body.body.flatMap(n => this.visit(n)),
+                        ),
+                    )
                 }
-            } else if (body.type === 'StaticBlock') {
-                const currentFuncDef = this.heuristciDetails.funcName
-                this.heuristciDetails.funcName = `${node.id.name}.[static]`
-                msgs.push(...body.body.flatMap(n => this.visit(n)))
-                this.heuristciDetails.funcName = currentFuncDef // restore
             }
-        }
-        this.heuristciDetails.declaring = prevDecl // restore
-        return msgs
+        })
+        return txts
     }
 
-    visitTemplateLiteralQuasis(node: Estree.TemplateLiteral, forHeuristic = false): [Message, number, Message[]] {
-        const msgs: Message[] = []
-        let msgStr = node.quasis[0]!.value?.cooked ?? ''
+    visitTemplateLiteralQuasis(node: Estree.TemplateLiteral, forHeuristic = false): [Text, number, Text[]] {
+        const txts: Text[] = []
+        let body = node.quasis[0]!.value?.cooked ?? ''
         const placeholders: [string, string][] = []
         for (const [i, expr] of node.expressions.entries()) {
             const quasi = node.quasis[i + 1]!
-            msgStr += `{${i}}${quasi.value.cooked}`
+            body += `{${i}}${quasi.value.cooked}`
             placeholders.push([i.toString(), this.content.slice(expr.start, expr.end)])
             if (forHeuristic) {
                 // skip modifications and sub visits
                 continue
             }
-            msgs.push(...this.visit(expr))
+            txts.push(...this.visit(expr))
             const { start, end } = quasi
             this.mstr.remove(start - 1, end)
             if (i + 1 === node.expressions.length) {
@@ -807,31 +787,31 @@ export class Transformer extends InertVisitors {
             }
             this.mstr.update(end, end + 2, ', ')
         }
-        const msgInfo = newMessage({
-            msgStr: [msgStr],
-            details: this.fullHeuristicDetails({ scope: 'script' }),
+        const msgInfo = newText({
+            body: [body],
+            path: this.scopePath,
             context: this.commentDirectives.context,
             placeholders,
         })
-        msgs.push(msgInfo)
-        return [msgInfo, forHeuristic ? 0 : this.index.get(getKey(msgInfo.msgStr, msgInfo.context)), msgs]
+        txts.push(msgInfo)
+        return [msgInfo, forHeuristic ? 0 : this.index.get(getKey(msgInfo.body, msgInfo.context)), txts]
     }
 
-    visitTemplateLiteral(node: Estree.TemplateLiteral, heurDetails: HeuristicDetailsBase | boolean = false): Message[] {
-        let msgTyp: MessageType = 'message'
-        let visitRes: [Message, number, Message[]]
-        if (heurDetails === true) {
+    visitTemplateLiteral(node: Estree.TemplateLiteral, bypassHeuristic = false): Text[] {
+        let msgTyp: TextType = 'message'
+        let visitRes: [Text, number, Text[]]
+        if (bypassHeuristic) {
             visitRes = this.visitTemplateLiteralQuasis(node)
         } else {
             const [msgInfoHeu] = this.visitTemplateLiteralQuasis(node, true)
-            const [heuRes] = this.checkHeuristicAllowNew(msgInfoHeu.msgStr[0]!, heurDetails || { scope: 'script' })
+            const [heuRes] = this.checkHeuristicAllowNew(msgInfoHeu.body[0]!)
             if (!heuRes) {
                 return node.expressions.flatMap(n => this.visit(n))
             }
             msgTyp = heuRes
             visitRes = this.visitTemplateLiteralQuasis(node)
         }
-        const [msgInfo, index, msgs] = visitRes
+        const [msgInfo, index, txts] = visitRes
         msgInfo.type = msgTyp
         const { start: start0, end: end0 } = node.quasis[0]!
         let begin = `${this.vars().rtTrans}(${index}`
@@ -848,64 +828,61 @@ export class Transformer extends InertVisitors {
         } else {
             this.mstr.update(start0 - 1, end0 + 1, begin + end)
         }
-        return msgs
+        return txts
     }
 
-    visitTaggedTemplateExpression(node: Estree.TaggedTemplateExpression): Message[] {
-        const prevCall = this.heuristciDetails.call
-        this.heuristciDetails.call = this.getCalleeName(node.tag)
-        let msgs: Message[] = []
-        const [msgInfoHeu] = this.visitTemplateLiteralQuasis(node.quasi, true)
-        const [heuRes] = this.checkHeuristicAllowNew(msgInfoHeu.msgStr[0]!, { scope: 'script' })
-        if (heuRes) {
-            const [msgInfo, index, msgsNew] = this.visitTemplateLiteralQuasis(node.quasi)
-            msgInfo.type = heuRes
-            msgs = msgsNew
-            this.mstr.appendRight(node.tag.start, `${this.vars().rtTransTag}(`)
-            const { start, end, expressions } = node.quasi
-            if (expressions.length > 0) {
-                this.mstr.update(start, expressions[0]!.start, `, ${index}, [`)
-                this.mstr.update(end - 1, end, `])`)
-            } else {
-                this.mstr.remove(start, start + 1)
-                this.mstr.update(start, end, `, ${index})`)
+    visitTaggedTemplateExpression(node: Estree.TaggedTemplateExpression): Text[] {
+        return this.inScope({ type: 'call', kind: 'tagged', name: this.getCalleeName(node.tag) }, () => {
+            let txts: Text[] = []
+            const [msgInfoHeu] = this.visitTemplateLiteralQuasis(node.quasi, true)
+            const [heuRes] = this.checkHeuristicAllowNew(msgInfoHeu.body[0]!)
+            if (heuRes) {
+                const [msgInfo, index, msgsNew] = this.visitTemplateLiteralQuasis(node.quasi)
+                msgInfo.type = heuRes
+                txts = msgsNew
+                this.mstr.appendRight(node.tag.start, `${this.vars().rtTransTag}(`)
+                const { start, end, expressions } = node.quasi
+                if (expressions.length > 0) {
+                    this.mstr.update(start, expressions[0]!.start, `, ${index}, [`)
+                    this.mstr.update(end - 1, end, `])`)
+                } else {
+                    this.mstr.remove(start, start + 1)
+                    this.mstr.update(start, end, `, ${index})`)
+                }
             }
-        }
-        this.heuristciDetails.call = prevCall
-        return msgs
+            return txts
+        })
     }
 
-    visitTryStatement(node: Estree.TryStatement): Message[] {
-        const msgs = this.visit(node.block)
+    visitTryStatement(node: Estree.TryStatement): Text[] {
+        const txts = this.visit(node.block)
         if (node.handler) {
-            msgs.push(...this.visit(node.handler.body))
+            txts.push(...this.visit(node.handler.body))
         }
         if (node.finalizer) {
-            msgs.push(...this.visit(node.finalizer))
+            txts.push(...this.visit(node.finalizer))
         }
-        return msgs
+        return txts
     }
 
-    visitTSAsExpression(node: Estree.TSAsExpression): Message[] {
+    visitTSAsExpression(node: Estree.TSAsExpression): Text[] {
         return this.visit(node.expression)
     }
 
-    visitTSTypeAssertion(node: Estree.TSTypeAssertion): Message[] {
+    visitTSTypeAssertion(node: Estree.TSTypeAssertion): Text[] {
         return this.visit(node.expression)
     }
 
-    visitTSSatisfiesExpression(node: Estree.TSSatisfiesExpression): Message[] {
+    visitTSSatisfiesExpression(node: Estree.TSSatisfiesExpression): Text[] {
         return this.visit(node.expression)
     }
 
-    visitProgram(node: Estree.Program): Message[] {
-        this.heuristciDetails.insideProgram = true
-        const msgs = this.visitStatementsNSaveRealBodyStart(node.body)
-        this.heuristciDetails.insideProgram = false
-        return msgs
+    visitProgram(node: Estree.Program): Text[] {
+        const txts = this.visitStatementsNSaveRealBodyStart(node.body)
+        return txts
     }
 
-    visitWithCommentDirectives(node: Estree.AnyNode, func: () => Message[]) {
+    visitWithCommentDirectives(node: Estree.AnyNode, func: () => Text[]) {
         const commentDirectives = { ...this.commentDirectives }
         // for estree
         const comments = this.comments[node.start]
@@ -921,25 +898,25 @@ export class Transformer extends InertVisitors {
         return res
     }
 
-    visit(node: Estree.AnyNode): Message[] {
+    visit(node: Estree.AnyNode): Text[] {
         return this.visitWithCommentDirectives(node, () => {
             if (this.commentDirectives.forceType === false) {
                 return []
             }
-            let msgs: Message[] = []
+            let txts: Text[] = []
             const visitor = this[`visit${node.type}` as `visit${typeof node.type}`]
             if (visitor != null) {
-                msgs = visitor.bind(this)(node as any)
+                txts = visitor.bind(this)(node as any)
                 // } else {
                 //     console.log(node)
             }
-            return msgs
+            return txts
         })
     }
 
-    finalize(msgs: Message[], hmrHeaderIndex: number, additionalHeader = ''): TransformOutput {
+    finalize(txts: Text[], hmrHeaderIndex: number, additionalHeader = ''): TransformOutput {
         return {
-            msgs,
+            txts: txts,
             output: header => {
                 this.mstr.prependRight(hmrHeaderIndex, `\n${header}\n${additionalHeader}\n`)
                 return {

--- a/packages/wuchale/src/adapters.test.ts
+++ b/packages/wuchale/src/adapters.test.ts
@@ -1,27 +1,24 @@
 // $ node --import ../testing/resolve.ts %f
 
 import { test } from 'node:test'
-import { createHeuristic, defaultHeuristicOpts, newMessage } from './adapters.js'
+import { createHeuristic, defaultHeuristicOpts, newText } from './text.js'
 
 const heuristic = createHeuristic(defaultHeuristicOpts)
 
-function scriptMsg(msgStr: string) {
-    return newMessage({
-        msgStr: [msgStr],
-        details: {
-            file: 'test.ts',
-            scope: 'script',
-            insideProgram: true,
-            funcName: 'myFn',
-        },
+function scriptTxt(body: string) {
+    return newText({
+        body: [body],
+        path: [{ type: 'function', name: 'myFn' }],
     })
 }
 
+const file = 'test.ts'
+
 test('Default heuristic checks correct', t => {
-    t.assert.equal(heuristic(scriptMsg('{0} was successfully deleted!')), 'message')
-    t.assert.equal(heuristic(scriptMsg("{0}'s role was updated to administrator.")), 'message')
-    t.assert.equal(heuristic(scriptMsg('{0}/api/users')), false)
-    t.assert.equal(heuristic(scriptMsg('{0}')), false)
-    t.assert.equal(heuristic(scriptMsg('Hello world')), 'message')
-    t.assert.equal(heuristic(scriptMsg('someVariable')), false)
+    t.assert.equal(heuristic(scriptTxt('{0} was successfully deleted!'), file), 'message')
+    t.assert.equal(heuristic(scriptTxt("{0}'s role was updated to administrator."), file), 'message')
+    t.assert.equal(heuristic(scriptTxt('{0}/api/users'), file), false)
+    t.assert.equal(heuristic(scriptTxt('{0}'), file), false)
+    t.assert.equal(heuristic(scriptTxt('Hello world'), file), 'message')
+    t.assert.equal(heuristic(scriptTxt('someVariable'), file), false)
 })

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -1,5 +1,5 @@
 import type { StorageFactory } from './storage.js'
-import type { HeuristicFunc, Text } from './text.js'
+import type { HeuristicFunc, Scope, Text } from './text.js'
 
 export const getKey = (text: string[], context?: string) => `${text.join('\n')}\n${context ?? ''}`.trim()
 
@@ -68,12 +68,11 @@ export type TransformFuncAsync = (expr: TransformCtx) => Promise<TransformOutput
 
 export type WrapFunc = (expr: string) => string
 
-export type DecideReactiveDetails<RTCtxT = any /* can be changed at the adapter */> = {
-    funcName?: string | undefined
-    nested: boolean
-    file: string
-    ctx: RTCtxT
-}
+export type DecideReactiveArgs<RTCtxT = any /* can be changed at the adapter */> = [
+    path: Scope[],
+    file: string,
+    ctx: RTCtxT,
+]
 
 type RuntimeConfDetails = {
     wrapInit: WrapFunc
@@ -82,8 +81,8 @@ type RuntimeConfDetails = {
 
 export type RuntimeConf = {
     /** return null to disable */
-    initReactive: (details: DecideReactiveDetails) => boolean | null
-    useReactive: boolean | ((details: DecideReactiveDetails) => boolean)
+    initReactive: (...args: DecideReactiveArgs) => boolean | null
+    useReactive: boolean | ((...args: DecideReactiveArgs) => boolean)
     plain: RuntimeConfDetails
     reactive: RuntimeConfDetails
 }

--- a/packages/wuchale/src/adapters.ts
+++ b/packages/wuchale/src/adapters.ts
@@ -1,171 +1,7 @@
 import type { StorageFactory } from './storage.js'
-
-type TxtScope = 'script' | 'markup' | 'attribute'
-
-export type HeuristicDetailsBase = {
-    scope: TxtScope
-    element?: string | undefined
-    attribute?: string | undefined
-}
-
-export type ScriptDeclType = 'variable' | 'function' | 'class' | 'expression'
-
-export type HeuristicDetails = HeuristicDetailsBase & {
-    file: string
-    /** the type of the top level declaration */
-    declaring?: ScriptDeclType | undefined
-    /** in assignments, whether the string is on the left side as destructuring default */
-    leftSide?: boolean | undefined
-    /** the name of the function being defined, '' for arrow or null for global */
-    funcName?: string | null | undefined
-    /** whether the function being defined is nested inside another, null for no function */
-    funcIsNested?: boolean | undefined
-    /** whether inside a script file/<script> instead of an expression inside markup */
-    insideProgram: boolean
-    /** the name of the call at the top level */
-    topLevelCall?: string | undefined
-    /** the name of the nearest call (for arguments) */
-    call?: string | undefined
-    /** inside an export const ... etc */
-    exported?: boolean | undefined
-    /** object property path */
-    property?: string | undefined
-}
-
-export type MessageType = 'message' | 'url'
-
-export type Message = {
-    msgStr: string[] // array for plurals
-    context?: string | undefined
-    placeholders: [string, string][]
-    details: HeuristicDetails
-    type: MessageType
-}
-
-export function newMessage(init: Partial<Message>): Message {
-    init.msgStr = init.msgStr?.filter(str => str != null) ?? []
-    if (init.details?.scope === 'markup') {
-        init.msgStr = init.msgStr.map(msg => msg.replace(/\s+/g, ' ').trim())
-    }
-    return {
-        msgStr: init.msgStr,
-        placeholders: init.placeholders ?? [],
-        type: init.type ?? 'message',
-        context: init.context,
-        details: init.details ?? {
-            file: '',
-            scope: 'markup',
-            insideProgram: true,
-        },
-    }
-}
+import type { HeuristicFunc, Text } from './text.js'
 
 export const getKey = (text: string[], context?: string) => `${text.join('\n')}\n${context ?? ''}`.trim()
-
-export type HeuristicResultChecked = MessageType | false // after checking all heuristic functions
-export type HeuristicResult = HeuristicResultChecked | null | undefined
-
-export type HeuristicFunc = (msg: Message) => HeuristicResult
-
-export const defaultHeuristicOpts = {
-    ignoreElements: ['script', 'style', 'path', 'code', 'pre'],
-    ignoreAttribs: [['form', 'method']],
-    ignoreCalls: ['fetch'],
-    urlAttribs: [['a', 'href']],
-    urlCalls: [] as string[],
-    urlProps: ['href', 'link', 'url'],
-}
-
-export type CreateHeuristicOpts = typeof defaultHeuristicOpts
-
-export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
-    return msg => {
-        if (msg.details.element && opts.ignoreElements.includes(msg.details.element)) {
-            return false
-        }
-        if (msg.details.scope === 'attribute') {
-            for (const [element, attrib] of opts.ignoreAttribs) {
-                if (msg.details.element === element && msg.details.attribute === attrib) {
-                    return false
-                }
-            }
-        }
-        let msgStr = msg.msgStr.join('\n')
-        if (msg.details.scope === 'markup') {
-            // only check the top level for letters
-            msgStr = msgStr.replaceAll(/<\d+\/>/g, '#').replaceAll(/<\d+>.+<\/\d+>/g, '#')
-        }
-        const looksLikeUrlPath = msgStr.startsWith('/') && !msgStr.includes(' ')
-        if (looksLikeUrlPath && (msg.details.scope === 'script' || msg.details.scope === 'attribute')) {
-            if (msg.details.call) {
-                for (const call of opts.urlCalls) {
-                    if (msg.details.call === call) {
-                        return 'url'
-                    }
-                }
-            }
-            if (msg.details.property) {
-                for (const prop of opts.urlProps) {
-                    if (msg.details.property === prop || msg.details.property?.endsWith(`.${prop}`)) {
-                        return 'url'
-                    }
-                }
-            }
-            if (msg.details.attribute) {
-                for (const [element, attrib] of opts.urlAttribs) {
-                    if (msg.details.element === element && msg.details.attribute === attrib) {
-                        return 'url'
-                    }
-                }
-            }
-        }
-        if (!/\p{L}/u.test(msgStr)) {
-            return false
-        }
-        if (msg.details.scope === 'markup') {
-            return 'message'
-        }
-        // script and attribute
-        if (/^([A-Z]|\P{L})+$/u.test(msgStr)) {
-            // only upper-case English and non-letters
-            return false
-        }
-        if (/^\{\d+\}/.test(msgStr)) {
-            // template literals that begin with a placeholder expression
-            if (!/\s\p{L}/u.test(msgStr)) {
-                // should contain spaces and letters
-                return false
-            }
-        } else if (/[a-z]|\P{L}/u.test(msgStr[0]!)) {
-            // ignore non-letter and lower-case English beginnings
-            return false
-        }
-        if (msg.details.scope === 'attribute') {
-            return 'message'
-        }
-        if (msg.details.declaring === 'expression' && msg.details.funcName == null) {
-            return false
-        }
-        if (
-            !msg.details.call ||
-            (!msg.details.call.startsWith('console.') && !opts.ignoreCalls.includes(msg.details.call))
-        ) {
-            return 'message'
-        }
-        return false
-    }
-}
-
-/** Default heuristic */
-export const defaultHeuristic = createHeuristic(defaultHeuristicOpts)
-
-/** Default heuristic which ignores messages outside functions in the `script` scope */
-export const defaultHeuristicFuncOnly: HeuristicFunc = msg => {
-    if (defaultHeuristic(msg) && (msg.details.scope !== 'script' || msg.details.funcName != null)) {
-        return 'message'
-    }
-    return false
-}
 
 export class IndexTracker {
     #indices: Map<string, number> = new Map()
@@ -176,18 +12,18 @@ export class IndexTracker {
         this.#bypassHas = bypassHas
     }
 
-    get = (msgStr: string) => {
-        let index = this.#indices.get(msgStr)
+    get = (txt: string) => {
+        let index = this.#indices.get(txt)
         if (index != null) {
             return index
         }
         index = this.#nextIndex
-        this.#indices.set(msgStr, index)
+        this.#indices.set(txt, index)
         this.#nextIndex++
         return index
     }
 
-    has = (msgStr: string) => this.#bypassHas || this.#indices.has(msgStr)
+    has = (txt: string) => this.#bypassHas || this.#indices.has(txt)
 
     getAll = () => this.#indices.entries()
 }
@@ -224,7 +60,7 @@ export type TransformOutputFunc = (header: string) => TransformOutputCode
 
 export type TransformOutput = {
     output: TransformOutputFunc
-    msgs: Message[]
+    txts: Text[]
 }
 
 export type TransformFunc = (expr: TransformCtx) => TransformOutput

--- a/packages/wuchale/src/ai/index.test.ts
+++ b/packages/wuchale/src/ai/index.test.ts
@@ -59,7 +59,7 @@ test('Group and prep items', async (t: TestContext) => {
     const opInfo = queue.prepItemsInBatches(groupedItems)
     // batchSize 4
     // for group in [es, de&am]
-    //  batchSize msg * 7 batch + 2 msg * 1 batch = 30
-    //  batch msgs = 7 + 1 = 8
+    //  batchSize txt * 7 batch + 2 txt * 1 batch = 30
+    //  batch txts = 7 + 1 = 8
     t.assert.equal(opInfo.length, 16)
 })

--- a/packages/wuchale/src/ai/index.ts
+++ b/packages/wuchale/src/ai/index.ts
@@ -11,7 +11,7 @@ const MAX_RETRIES = 30
 type Batch = {
     id: number
     targetLocales: string[]
-    messages: Item[]
+    items: Item[]
 }
 
 type GroupKey = string | string[]
@@ -24,7 +24,7 @@ export type AIPassThruOpts = {
 
 export type AI = AIPassThruOpts & {
     name: string
-    translate: (messages: string, instruction: string) => Promise<string>
+    translate: (body: string, instruction: string) => Promise<string>
 }
 
 // by locale
@@ -107,7 +107,7 @@ export default class AIQueue {
         const logStart = this.#logStart(batch.id, batch.targetLocales)
         let translated: OutputItem[] = []
         try {
-            const inputItems: InputItem[] = batch.messages.map(item => ({
+            const inputItems: InputItem[] = batch.items.map(item => ({
                 id: item.translations.get(this.sourceLocale)!,
                 context: item.context,
                 references: item.references,
@@ -118,7 +118,7 @@ export default class AIQueue {
             )
             translated = JSON.parse(translatedstr)
             if (Array.isArray(translated)) {
-                translated = translated.slice(0, batch.messages.length) // may return more
+                translated = translated.slice(0, batch.items.length) // may return more
             } else {
                 translated = []
             }
@@ -126,9 +126,9 @@ export default class AIQueue {
             this.log.error(logStart, `error: ${err}`)
             return
         }
-        const unTranslated: Item[] = batch.messages.slice(translated.length)
+        const unTranslated: Item[] = batch.items.slice(translated.length)
         for (const [i, outItem] of translated.entries()) {
-            const item = batch.messages[i]!
+            const item = batch.items[i]!
             const id = item.translations.get(this.sourceLocale)!
             const sourceComp = id.map(i => compileTranslation(i, ''))
             for (const loc of batch.targetLocales) {
@@ -174,8 +174,8 @@ export default class AIQueue {
             this.log.error(logStart, `Giving up after ${attempt} unsuccessful retries`)
             return
         }
-        this.log.warn(logStart, color.cyan(unTranslated.length), 'messages not translated. Retrying...')
-        batch.messages = unTranslated
+        this.log.warn(logStart, color.cyan(unTranslated.length), 'items not translated. Retrying...')
+        batch.items = unTranslated
         await this.translate(batch, attempt)
     }
 
@@ -225,11 +225,11 @@ export default class AIQueue {
         for (let [groupKey, items] of itemsByGroup) {
             const groupBatches = this.batches.get(groupKey) ?? []
             const lastBatch = groupBatches.at(-1)
-            if (lastBatch && lastBatch.messages.length < this.ai.batchSize) {
-                const lastBatchFree = this.ai.batchSize - lastBatch.messages.length
+            if (lastBatch && lastBatch.items.length < this.ai.batchSize) {
+                const lastBatchFree = this.ai.batchSize - lastBatch.items.length
                 const itemsToAdd = items.slice(0, lastBatchFree)
                 opInfo.push(['(add)', lastBatch, itemsToAdd.length])
-                lastBatch.messages.push(...itemsToAdd)
+                lastBatch.items.push(...itemsToAdd)
                 items = items.slice(lastBatchFree)
             }
             for (let i = 0; i < items.length; i += this.ai.batchSize) {
@@ -237,7 +237,7 @@ export default class AIQueue {
                 const batch: Batch = {
                     id: this.nextBatchId,
                     targetLocales: Array.isArray(groupKey) ? groupKey : [groupKey],
-                    messages: chunk,
+                    items: chunk,
                 }
                 groupBatches.push(batch)
                 opInfo.push([color.yellow('(new)'), batch, chunk.length])
@@ -265,7 +265,7 @@ export default class AIQueue {
                 opType,
                 'translate',
                 color.cyan(msgsLen),
-                'messages',
+                'items',
             )
         }
         if (!this.running) {

--- a/packages/wuchale/src/cli/check.ts
+++ b/packages/wuchale/src/cli/check.ts
@@ -8,7 +8,7 @@ Usage:
     ${color.cyan('wuchale check {options}')}
 
 Options:
-    ${color.cyan('--full')}           check if there are unextracted and newly obsolete messages in source code as well
+    ${color.cyan('--full')}           check if there are unextracted and newly obsolete items in source code as well
     ${color.cyan('--help')}, ${color.cyan('-h')}       Show this help
 `
 

--- a/packages/wuchale/src/cli/index.ts
+++ b/packages/wuchale/src/cli/index.ts
@@ -58,14 +58,14 @@ Usage:
     ${color.cyan('wuchale [command] {options}')}
 
 Commands:
-    ${color.grey('[none]')}  Extract/compile messages from the codebase into catalogs
-            deleting unused messages if ${color.cyan('--clean')} is specified
+    ${color.grey('[none]')}  Extract/compile texts from the codebase into catalogs
+            deleting unused items if ${color.cyan('--clean')} is specified
     ${color.cyan('status')}  Show current status
     ${color.cyan('check')}   Check for errors
 
 Options:
     ${color.cyan('--config')}         Use another config file instead of ${defaultConfigNames.map(color.cyan).join('|')}
-    ${color.cyan('--clean')}, ${color.cyan('-c')}      Remove unused messages from catalogs
+    ${color.cyan('--clean')}, ${color.cyan('-c')}      Remove unused items from catalogs
     ${color.cyan('--watch')}, ${color.cyan('-w')}      Continuously watch for file changes
     ${color.cyan('--sync')}           Extract sequentially instead of in parallel
     ${color.cyan('--modify a1,a2')}   Modify files in place for adapters ${color.cyan('a1')}, ${color.cyan('a2')}, etc.

--- a/packages/wuchale/src/compile.test.ts
+++ b/packages/wuchale/src/compile.test.ts
@@ -3,9 +3,9 @@
 import { type TestContext, test } from 'node:test'
 import { type CompiledElement, compileTranslation, isEquivalent } from './compile.js'
 
-test('Compile messages', t => {
-    const testCompile = (msg: string, expect: CompiledElement) =>
-        t.assert.deepEqual(compileTranslation(msg, 'Fallback'), expect)
+test('Compile items', t => {
+    const testCompile = (txt: string, expect: CompiledElement) =>
+        t.assert.deepEqual(compileTranslation(txt, 'Fallback'), expect)
     testCompile('Foo', 'Foo')
     testCompile('Foo {0}', ['Foo ', 0])
     testCompile('Foo <0>bar</0>', ['Foo ', [0, 'bar']])

--- a/packages/wuchale/src/compile.ts
+++ b/packages/wuchale/src/compile.ts
@@ -11,9 +11,9 @@ const PLACEHOLDER = Symbol()
 
 const digitRange = ['0', '9'].map(d => d.charCodeAt(0)) as [number, number]
 
-function extractSpecial(msgStr: string, start: number): [symbol | null, number | null, number] {
-    const inPlaceHolder = msgStr[start] === '{'
-    const inTag = msgStr[start] === '<'
+function extractSpecial(txt: string, start: number): [symbol | null, number | null, number] {
+    const inPlaceHolder = txt[start] === '{'
+    const inTag = txt[start] === '<'
     if (!inTag && !inPlaceHolder) {
         return [null, null, start]
     }
@@ -21,13 +21,13 @@ function extractSpecial(msgStr: string, start: number): [symbol | null, number |
     let endChar = ''
     let inClose = false
     let i = start + 1
-    const beginChar = msgStr[i]
+    const beginChar = txt[i]
     if (inTag && beginChar === '/') {
         inClose = true
         i++
     }
-    while (i < msgStr.length) {
-        const char = msgStr[i]!
+    while (i < txt.length) {
+        const char = txt[i]!
         const code = char.charCodeAt(0)
         if (code < digitRange[0] || code > digitRange[1]) {
             endChar = char
@@ -46,7 +46,7 @@ function extractSpecial(msgStr: string, start: number): [symbol | null, number |
         }
         return [PLACEHOLDER, n, i + 1]
     }
-    if (endChar === '/' && msgStr[i + 1] === '>') {
+    if (endChar === '/' && txt[i + 1] === '>') {
         return [SELF_CLOSE, n, i + 2]
     }
     if (endChar !== '>') {
@@ -58,19 +58,15 @@ function extractSpecial(msgStr: string, start: number): [symbol | null, number |
     return [OPEN, n, i + 1]
 }
 
-function compile(
-    msgStr: string,
-    start = 0,
-    parentTag: number | null = null,
-): [CompositePayload[], number, string | null] {
+function compile(txt: string, start = 0, parentTag: number | null = null): [CompositePayload[], number, string | null] {
     let curTxt = ''
     const compiled: CompositePayload[] = []
     let i = start
-    const len = msgStr.length
+    const len = txt.length
     let currentOpenTag: number | null = null
     while (i < len) {
-        const char = msgStr[i]
-        const [type, n, newI] = extractSpecial(msgStr, i)
+        const char = txt[i]
+        const [type, n, newI] = extractSpecial(txt, i)
         if (type === null) {
             curTxt += char
             i++
@@ -82,7 +78,7 @@ function compile(
         }
         if (type === OPEN) {
             currentOpenTag = n
-            const [subExt, newIc] = compile(msgStr, newI, n)
+            const [subExt, newIc] = compile(txt, newI, n)
             compiled.push([n as number, ...subExt])
             i = newIc
             continue
@@ -115,13 +111,13 @@ function compile(
     return [compiled, i, null]
 }
 
-export function compileTranslation(msgStr: string, fallback: CompiledElement): CompiledElement {
-    if (!msgStr) {
+export function compileTranslation(txt: string, fallback: CompiledElement): CompiledElement {
+    if (!txt) {
         return fallback
     }
-    const [compiled, , err] = compile(msgStr)
+    const [compiled, , err] = compile(txt)
     if (err !== null) {
-        console.error('Compile error:', err, ':', msgStr)
+        console.error('Compile error:', err, ':', txt)
         return fallback
     }
     if (compiled.length === 1 && typeof compiled[0] === 'string') {

--- a/packages/wuchale/src/handler/index.test.ts
+++ b/packages/wuchale/src/handler/index.test.ts
@@ -5,9 +5,10 @@ import { type TestContext, test } from 'node:test'
 // @ts-expect-error
 import { dummyTransform, inMemFS, inMemStorage, trimLines, ts } from '../../testing/utils.ts'
 import { defaultArgs } from '../adapter-vanilla/index.js'
-import { type Adapter, newMessage } from '../adapters.js'
+import type { Adapter } from '../adapters.js'
 import { defaultConfig } from '../config.js'
 import { Logger } from '../log.js'
+import { newText } from '../text.js'
 import { generatedDir } from './files.js'
 import { AdapterHandler, getFallbackChains } from './index.js'
 import { SharedState } from './state.js'
@@ -83,22 +84,21 @@ test('Manifest', async (t: TestContext) => {
     )
 })
 
-test('Handle messages', async (t: TestContext) => {
-    const msgs = [newMessage({ msgStr: ['Hello'] })]
-    const [hmrKeys, updated] = await handler.handleMessages(msgs, 'foo.ts', 0)
+test('Handle texts', async (t: TestContext) => {
+    const txts = [newText({ body: ['Hello'] })]
+    const [hmrKeys, updated] = await handler.handleTexts(txts, 'foo.ts', 0)
     t.assert.strictEqual(updated, true)
     t.assert.deepStrictEqual(hmrKeys, ['Hello'])
-    // @ts-expect-error
-    const msgs1 = [newMessage({ msgStr: ['Hello'], context: null })]
-    const [, updated1] = await handler.handleMessages(msgs1, 'foo.ts', 0)
+    const msgs1 = [newText({ body: ['Hello'], context: undefined })]
+    const [, updated1] = await handler.handleTexts(msgs1, 'foo.ts', 0)
     t.assert.strictEqual(updated1, false)
-    const [, updated2] = await handler.handleMessages(msgs, 'bar.ts', 0)
+    const [, updated2] = await handler.handleTexts(txts, 'bar.ts', 0)
     t.assert.strictEqual(updated2, true)
 })
 
 test('Handler compiles only when necessary', async (t: TestContext) => {
     const handler = await makeHandler()
-    const msgs = [newMessage({ msgStr: ['Hello'] })]
+    const txts = [newText({ body: ['Hello'] })]
     let saveCalls = 0
     let compileCalls = 0
     const handlerSaveStorage = handler.saveStorage.bind(handler)
@@ -111,11 +111,11 @@ test('Handler compiles only when necessary', async (t: TestContext) => {
         compileCalls++
         return handlerCompile(...args)
     }
-    const [, updated1] = await handler.handleMessages(msgs, 'foo.ts', 0)
+    const [, updated1] = await handler.handleTexts(txts, 'foo.ts', 0)
     t.assert.strictEqual(updated1, true)
     t.assert.strictEqual(saveCalls, 1)
     t.assert.strictEqual(compileCalls, 1)
-    const [, updated2] = await handler.handleMessages(msgs, 'bar.ts', 0)
+    const [, updated2] = await handler.handleTexts(txts, 'bar.ts', 0)
     t.assert.strictEqual(updated2, true)
     t.assert.strictEqual(saveCalls, 2)
     t.assert.strictEqual(compileCalls, 1)

--- a/packages/wuchale/src/handler/index.ts
+++ b/packages/wuchale/src/handler/index.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { isDeepStrictEqual } from 'node:util'
 import pm, { type Matcher } from 'picomatch'
 import { varNames } from '../adapter-utils/index.js'
-import type { Adapter, Message, RuntimeExpr, TransformOutputCode } from '../adapters.js'
+import type { Adapter, RuntimeExpr, TransformOutputCode } from '../adapters.js'
 import { getKey } from '../adapters.js'
 import AIQueue from '../ai/index.js'
 import { type CompiledElement, compileTranslation } from '../compile.js'
@@ -12,6 +12,7 @@ import type { HMRData } from '../dev.js'
 import { readOnlyFS } from '../fs.js'
 import type { Logger } from '../log.js'
 import { type FileRef, type FileRefEntry, type Item, itemIsUrl, newItem } from '../storage.js'
+import type { Text } from '../text.js'
 import {
     defaultLoadID,
     Files,
@@ -408,15 +409,15 @@ export class AdapterHandler {
         return previousReferences
     }
 
-    updateRef = (item: Item, key: string, filename: string, msgInfo: Message, trackedRefrences: TrackedRefs) => {
+    updateRef = (item: Item, key: string, filename: string, txt: Text, trackedRefrences: TrackedRefs) => {
         let updated = false
         const newRef: FileRefEntry = {
-            placeholders: msgInfo.placeholders.map(([i, p]) => [i, p.replace(/\s+/g, ' ').trim()]),
+            placeholders: txt.placeholders.map(([i, p]) => [i, p.replace(/\s+/g, ' ').trim()]),
         }
-        if (msgInfo.type === 'url' && getKey(msgInfo.msgStr, msgInfo.context) !== key) {
-            newRef.link = msgInfo.msgStr[0]!
+        if (txt.type === 'url' && getKey(txt.body, txt.context) !== key) {
+            newRef.link = txt.body[0]!
         }
-        const newRefEntry = newRef.link || msgInfo.placeholders.length ? newRef : null
+        const newRefEntry = newRef.link || txt.placeholders.length ? newRef : null
         const prevRef = trackedRefrences.get(key)
         if (prevRef == null) {
             const newFileRef: FileRef = {
@@ -461,7 +462,7 @@ export class AdapterHandler {
         return { cleaned, cleanedUrls }
     }
 
-    handleMessages = async (msgs: Message[], filename: string, hmrVersion: number): Promise<[string[], boolean]> => {
+    handleTexts = async (txts: Text[], filename: string, hmrVersion: number): Promise<[string[], boolean]> => {
         const previousReferences = this.popTrackedRefs(filename)
         let storageUpdated = false
         let compileUpdated = false
@@ -469,12 +470,12 @@ export class AdapterHandler {
         const toTranslate: Item[] = []
         const modifyExistingRefs =
             this.#opts.mode !== 'dev' || this.#opts.devMode === 'refs' || this.#opts.devMode === 'clean'
-        for (const msgInfo of msgs) {
-            let key = getKey(msgInfo.msgStr, msgInfo.context)
-            if (msgInfo.type === 'url') {
+        for (const txt of txts) {
+            let key = getKey(txt.body, txt.context)
+            if (txt.type === 'url') {
                 const matched = this.url.match(key)
                 if (!matched) {
-                    const err = new Error(`URL ${msgInfo.msgStr[0]} has no matching pattern defined`)
+                    const err = new Error(`URL ${txt.body[0]} has no matching pattern defined`)
                     ;(err as any).id = filename
                     throw err
                 }
@@ -482,7 +483,7 @@ export class AdapterHandler {
             }
             let item = this.sharedState.catalog.get(key)
             if (!item) {
-                item = newItem({ id: msgInfo.msgStr }, this.#opts.config.locales)
+                item = newItem({ id: txt.body }, this.#opts.config.locales)
                 this.sharedState.catalog.set(key, item)
                 this.#newKeys.add(key)
                 storageUpdated = true
@@ -492,27 +493,27 @@ export class AdapterHandler {
                 hmrKeys.push(key)
             }
             const modifyRefs = modifyExistingRefs || (this.#opts.devMode === 'add' && this.#newKeys.has(key))
-            if (modifyRefs && this.updateRef(item, key, filename, msgInfo, previousReferences)) {
+            if (modifyRefs && this.updateRef(item, key, filename, txt, previousReferences)) {
                 storageUpdated = true
-                if (msgInfo.type === 'url') {
+                if (txt.type === 'url') {
                     compileUpdated = true
                 }
             }
-            if (msgInfo.type === 'url') {
+            if (txt.type === 'url') {
                 // already translated or attempted at startup
                 // and context not to be updated
                 continue
             }
             // biome-ignore lint: noDoubleEquals: NOT !== because they may be null (from pofile!)
-            if (msgInfo.context != item.context) {
+            if (txt.context != item.context) {
                 storageUpdated = true
                 compileUpdated = true
             }
-            item.context = msgInfo.context
+            item.context = txt.context
             const sourceTransl = item.translations.get(this.sourceLocale)!
-            const msgStr = msgInfo.msgStr.join('\n')
-            if (sourceTransl.join('\n') !== msgStr) {
-                item.translations.set(this.sourceLocale, msgInfo.msgStr)
+            const body = txt.body.join('\n')
+            if (sourceTransl.join('\n') !== body) {
+                item.translations.set(this.sourceLocale, txt.body)
                 storageUpdated = true
                 compileUpdated = true
             }
@@ -561,7 +562,7 @@ export class AdapterHandler {
             loadID = state.id
             compiled = state.compiled
         }
-        const { msgs, ...result } = await this.adapter.transform({
+        const { txts, ...result } = await this.adapter.transform({
             content,
             filename,
             index: indexTracker,
@@ -572,16 +573,16 @@ export class AdapterHandler {
         let updated = false
         if (this.#opts.mode !== 'build') {
             if (this.#opts.log.checkLevel('verbose')) {
-                if (msgs.length) {
-                    this.#opts.log.verbose(`${this.key}: ${msgs.length} messages from ${filename}:`)
-                    for (const msg of msgs) {
-                        this.#opts.log.verbose(`  ${msg.msgStr.join(', ')} [${msg.details.scope}]`)
+                if (txts.length) {
+                    this.#opts.log.verbose(`${this.key}: ${txts.length} items from ${filename}:`)
+                    for (const txt of txts) {
+                        this.#opts.log.verbose(`  ${txt.body.join(', ')} [${txt.path.at(-1)!.type}]`)
                     }
                 } else {
-                    this.#opts.log.verbose(`${this.key}: No messages from ${filename}.`)
+                    this.#opts.log.verbose(`${this.key}: No items from ${filename}.`)
                 }
             }
-            const [hmrKeys, updatedItems] = await this.handleMessages(msgs, filename, hmrVersion)
+            const [hmrKeys, updatedItems] = await this.handleTexts(txts, filename, hmrVersion)
             updated = updatedItems
             if (!forServer && hmrKeys.length > 0) {
                 hmrData = {}
@@ -595,14 +596,14 @@ export class AdapterHandler {
             }
         }
         let output: TransformOutputCode = {}
-        if (msgs.length) {
+        if (txts.length) {
             output = result.output(
                 this.#prepareHeader(
                     filename,
                     loadID,
                     hmrData,
                     hmrVersion,
-                    msgs.some(m => m.type === 'url'),
+                    txts.some(m => m.type === 'url'),
                     forServer,
                 ),
             )

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -331,7 +331,7 @@ export class Hub {
             }
             const loadIDs = [defaultLoadID]
             for (const state of handler.granularState.byID.values()) {
-                // only the ones with ready messages
+                // only the ones with ready items
                 if (state.compiled.get(handler.sourceLocale)!.items.length) {
                     loadIDs.push(state.id)
                 }

--- a/packages/wuchale/src/index.ts
+++ b/packages/wuchale/src/index.ts
@@ -3,16 +3,9 @@ export type {
     AdapterArgs,
     AdapterPassThruOpts,
     CodePattern,
-    CreateHeuristicOpts,
     DecideReactiveDetails,
-    HeuristicDetails,
-    HeuristicDetailsBase,
-    HeuristicFunc,
-    HeuristicResult,
     LoaderChoice,
     LoadGroupPatt,
-    Message,
-    MessageType,
     RuntimeConf,
     RuntimeExpr,
     TransformCtx,
@@ -22,9 +15,6 @@ export type {
     UrlMatcher,
 } from './adapters.js'
 export {
-    createHeuristic,
-    defaultHeuristic,
-    defaultHeuristicOpts,
     getKey,
     IndexTracker,
 } from './adapters.js'
@@ -65,3 +55,17 @@ export type {
     StorageFactoryOpts,
 } from './storage.js'
 export { defaultPluralRule, mergeItemsByKey, migrateStorage, storageByLocale, storageByType } from './storage.js'
+export type {
+    CreateHeuristicOpts,
+    HeuristicFunc,
+    HeuristicResult,
+    Scope,
+    Text,
+    TextType,
+} from './text.js'
+export {
+    ascendPath,
+    createHeuristic,
+    defaultHeuristic,
+    defaultHeuristicOpts,
+} from './text.js'

--- a/packages/wuchale/src/index.ts
+++ b/packages/wuchale/src/index.ts
@@ -3,7 +3,7 @@ export type {
     AdapterArgs,
     AdapterPassThruOpts,
     CodePattern,
-    DecideReactiveDetails,
+    DecideReactiveArgs,
     LoaderChoice,
     LoadGroupPatt,
     RuntimeConf,

--- a/packages/wuchale/src/load-utils/index.test.ts
+++ b/packages/wuchale/src/load-utils/index.test.ts
@@ -23,8 +23,8 @@ test('Loading', async t => {
 
 test('Loading server side', async t => {
     const getRT = await loadLocales('main', 1, _ => testCatalog, ['en'])
-    const msg = await runWithLocale('en', () => {
+    const txt = await runWithLocale('en', () => {
         return getRT()(1, ['server user'])
     })
-    t.assert.equal(msg, 'Hello server user!')
+    t.assert.equal(txt, 'Hello server user!')
 })

--- a/packages/wuchale/src/runtime.test.ts
+++ b/packages/wuchale/src/runtime.test.ts
@@ -5,12 +5,12 @@ import { test } from 'node:test'
 import { testCatalog } from '../testing/utils.ts'
 import toRuntime from './runtime.js'
 
-function taggedHandler(msgs: TemplateStringsArray, ...args: any[]) {
-    let msg = msgs[0]
+function taggedHandler(txts: TemplateStringsArray, ...args: any[]) {
+    let txt = txts[0]
     for (const [i, arg] of args.entries()) {
-        msg += `${arg}${msgs[i + 1]}`
+        txt += `${arg}${txts[i + 1]}`
     }
-    return msg
+    return txt
 }
 
 test('Runtime', t => {

--- a/packages/wuchale/src/runtime.ts
+++ b/packages/wuchale/src/runtime.ts
@@ -34,17 +34,17 @@ export type Runtime = {
 
 /** get translation using composite context */
 function mixedToString(ctx: Mixed, args: any[] = [], start = 1) {
-    let msgStr = ''
+    let txt = ''
     for (let i = start; i < ctx.length; i++) {
         const fragment = ctx[i]!
         if (typeof fragment === 'string') {
-            msgStr += fragment
+            txt += fragment
         } else {
             // index of non-text children
-            msgStr += args[fragment]
+            txt += args[fragment]
         }
     }
-    return msgStr
+    return txt
 }
 
 export default function toRuntime(mod: CatalogModule = { c: [] }, locale = ''): Runtime {

--- a/packages/wuchale/src/storage.ts
+++ b/packages/wuchale/src/storage.ts
@@ -143,16 +143,16 @@ export function storageByType(storages: Record<ItemType, StorageFactory>): Stora
             },
             save: async ({ items, pluralRules }) => {
                 const urls: Item[] = []
-                const msgs: Item[] = []
+                const txts: Item[] = []
                 for (const item of items) {
-                    ;(itemIsUrl(item) ? urls : msgs).push(item)
+                    ;(itemIsUrl(item) ? urls : txts).push(item)
                 }
                 const promises: (void | Promise<void>)[] = []
                 if (urls.length) {
                     promises.push(byType.get('url')!.save({ items: urls, pluralRules }))
                 }
-                if (msgs.length) {
-                    promises.push(byType.get('message')!.save({ items: msgs, pluralRules }))
+                if (txts.length) {
+                    promises.push(byType.get('message')!.save({ items: txts, pluralRules }))
                 }
                 await Promise.all(promises)
             },

--- a/packages/wuchale/src/text.ts
+++ b/packages/wuchale/src/text.ts
@@ -1,0 +1,218 @@
+type ElementScope = {
+    type: 'element'
+    name: string
+}
+
+type AttributeScope = {
+    type: 'attribute'
+    name: string
+}
+
+type ExprScope = {
+    // as in {interpolations} in markup, or expression statement like 'use strict'
+    type: 'expression'
+}
+
+type ExportScope = {
+    type: 'export'
+}
+
+type FuncScope = {
+    type: 'function'
+    name: string
+}
+
+type ArrowScope = {
+    type: 'funcexpr'
+    kind: 'arrow' | 'function'
+}
+
+type AssignScope = {
+    type: 'assignment'
+} & (
+    | {
+          left: false
+          targets: string[]
+      }
+    | { left: true }
+)
+
+type ClassScope = {
+    type: 'class'
+    name: string
+}
+
+type MethodScope = {
+    type: 'method'
+    name: string
+}
+
+type CallScope = {
+    type: 'call'
+    kind: 'new' | 'tagged' | 'function'
+    name: string
+}
+
+type PropertyScope = {
+    type: 'property'
+    name: string
+}
+
+export type Scope =
+    | ElementScope
+    | AttributeScope
+    | ExprScope
+    | ExportScope
+    | FuncScope
+    | ArrowScope
+    | AssignScope
+    | ClassScope
+    | MethodScope
+    | CallScope
+    | PropertyScope
+
+export type TextType = 'message' | 'url'
+
+export type Text = {
+    type: TextType
+    body: string[] // array for plurals
+    context?: string | undefined
+    placeholders: [string, string][]
+    path: Scope[]
+}
+
+export type HeuristicResultChecked = TextType | false // after checking all heuristic functions
+export type HeuristicResult = HeuristicResultChecked | null | undefined
+
+export type HeuristicFunc = (txt: Text, file: string) => HeuristicResult
+
+export const defaultHeuristicOpts = {
+    ignoreElements: ['script', 'style', 'path', 'code', 'pre'],
+    ignoreAttribs: [['form', 'method']],
+    ignoreCalls: ['fetch'],
+    urlAttribs: [['a', 'href']],
+    urlCalls: [] as string[],
+    urlProps: ['href', 'link', 'url'],
+}
+
+export type CreateHeuristicOpts = typeof defaultHeuristicOpts
+
+const updatableScopes = new Set<Scope['type']>(['element', 'attribute', 'function', 'funcexpr', 'method'])
+
+export function* ascendPath(path: Scope[]) {
+    for (let i = path.length - 1; i >= 0; i--) {
+        yield path[i]!
+    }
+}
+
+export function createHeuristic(opts: CreateHeuristicOpts): HeuristicFunc {
+    return txt => {
+        let attribute = ''
+        let nearestElement = null
+        let updateable = false
+        for (const s of ascendPath(txt.path)) {
+            updateable ||= updatableScopes.has(s.type)
+            if (s.type === 'call' && (s.name.startsWith('console.') || opts.ignoreCalls.includes(s.name))) {
+                return false
+            }
+            if (s.type === 'attribute') {
+                attribute = s.name
+                continue
+            }
+            if (s.type === 'element') {
+                if (
+                    opts.ignoreElements.includes(s.name) ||
+                    opts.ignoreAttribs.some(([elm, att]) => s.name === elm && attribute === att)
+                ) {
+                    return false
+                }
+                nearestElement ||= s.name
+            }
+        }
+        let body = txt.body.join('\n')
+        const lastScope = txt.path.at(-1)!
+        if (lastScope.type === 'element') {
+            // only check the top level for letters
+            body = body.replaceAll(/<\d+\/>/g, '#').replaceAll(/<\d+>.+<\/\d+>/g, '#')
+        }
+        const looksLikeUrlPath = body.startsWith('/') && !body.includes(' ')
+        if (looksLikeUrlPath && lastScope.type !== 'element') {
+            if (lastScope.type === 'call') {
+                for (const call of opts.urlCalls) {
+                    if (lastScope.name === call) {
+                        return 'url'
+                    }
+                }
+            }
+            if (lastScope.type === 'property') {
+                for (const prop of opts.urlProps) {
+                    if (lastScope.name === prop) {
+                        return 'url'
+                    }
+                }
+            }
+            if (lastScope.type === 'attribute') {
+                for (const [tag, attrib] of opts.urlAttribs) {
+                    if (nearestElement === tag && lastScope.name === attrib) {
+                        return 'url'
+                    }
+                }
+            }
+        }
+        if (!/\p{L}/u.test(body)) {
+            return false
+        }
+        if (lastScope.type === 'element') {
+            return 'message'
+        }
+        // script and attribute
+        if (/^([A-Z]|\P{L})+$/u.test(body)) {
+            // only upper-case English and non-letters
+            return false
+        }
+        if (/^\{\d+\}/.test(body)) {
+            // template literals that begin with a placeholder expression
+            if (!/\s\p{L}/u.test(body)) {
+                // should contain spaces and letters
+                return false
+            }
+        } else if (/[a-z]|\P{L}/u.test(body[0]!)) {
+            // ignore non-letter and lower-case English beginnings
+            return false
+        }
+        if (lastScope.type === 'attribute') {
+            return 'message'
+        }
+        if (txt.path[0]?.type === 'expression' && !updateable) {
+            // bare expr statement outside markup
+            return false
+        }
+        return 'message'
+    }
+}
+
+/** Default heuristic */
+export const defaultHeuristic = createHeuristic(defaultHeuristicOpts)
+
+/** Default heuristic which ignores texts outside functions in the `script` scope */
+export const defaultHeuristicFuncOnly: HeuristicFunc = (txt, file) => {
+    const defaultRes = defaultHeuristic(txt, file)
+    if (defaultRes && txt.path.some(s => updatableScopes.has(s.type))) {
+        return defaultRes
+    }
+    return false
+}
+
+export function newText(init: Partial<Text>): Text {
+    init.body = init.body?.filter(str => str != null) ?? []
+    if (init?.path?.at(-1)?.type === 'element') {
+        init.body = init.body.map(str => str.replace(/\s+/g, ' ').trim())
+    }
+    return {
+        body: init.body,
+        placeholders: init.placeholders ?? [],
+        type: init.type ?? 'message',
+        context: init.context,
+        path: init.path?.slice() ?? [], // copy because visitors .push and .pop
+    }
+}

--- a/packages/wuchale/testing/utils.ts
+++ b/packages/wuchale/testing/utils.ts
@@ -1,9 +1,10 @@
 import { statfs } from 'node:fs/promises'
 import type { TestContext } from 'node:test'
 import { getDefaultLoaderPath } from '../src/adapter-vanilla/index.js'
-import { getKey, type Message, newMessage, type TransformFunc, type TransformOutput } from '../src/adapters.js'
+import { getKey, type TransformFunc, type TransformOutput } from '../src/adapters.js'
 import type { FS } from '../src/fs.js'
 import type { SaveData, StorageFactory } from '../src/storage.js'
+import { newText, type Text } from '../src/text.js'
 
 const header = 'import { _w_load_, _w_load_rx_ } from "./loader.js"' // just an example header
 
@@ -20,7 +21,7 @@ export const testCatalog = {
     ],
 }
 
-type TstMsg = Partial<Message>
+type TstTxt = Partial<Text>
 
 export function trimLines(str?: string) {
     if (!str) {
@@ -37,26 +38,26 @@ export function trimLines(str?: string) {
 
 export function transformTest(
     t: TestContext,
-    { msgs, output }: TransformOutput,
+    { txts, output }: TransformOutput,
     expectedContent: string | undefined,
-    expectedMsgs: (string | TstMsg)[],
+    expectedMsgs: (string | TstTxt)[],
 ) {
-    const code = msgs.length ? output(header).code : undefined
+    const code = txts.length ? output(header).code : undefined
     t.assert.strictEqual(trimLines(code), trimLines(expectedContent))
     t.assert.strictEqual(
-        msgs.length,
+        txts.length,
         expectedMsgs.length,
-        `Unexpected number of messages: ${msgs.length} !== ${expectedMsgs.length}\n${msgs.map(m => `  ${m.msgStr[0]}`).join('\n')}`,
+        `Unexpected number of messages: ${txts.length} !== ${expectedMsgs.length}\n${txts.map(m => `  ${m.body[0]}`).join('\n')}`,
     )
     for (let [i, exp] of expectedMsgs.entries()) {
         if (typeof exp === 'string') {
-            exp = { msgStr: [exp] }
+            exp = { body: [exp] }
         }
-        const msg = msgs[i]!
-        t.assert.deepStrictEqual(msg.msgStr, exp.msgStr, `Different msgStr`)
-        for (const prop of ['context', 'placeholders']) {
+        const txt = txts[i]!
+        t.assert.deepStrictEqual(txt.body, exp.body, `Different msgStr`)
+        for (const prop of ['context', 'placeholders'] as const) {
             if (prop in exp) {
-                t.assert.deepStrictEqual(msg[prop as keyof Message], exp[prop as keyof Message], `Different ${prop}`)
+                t.assert.deepStrictEqual(txt[prop], exp[prop], `Different ${prop}`)
             }
         }
     }
@@ -75,7 +76,7 @@ export const testLoadersExist = async (loaders: string[], getLoaderPath = getDef
 }
 
 export const dummyTransform: TransformFunc = ctx => {
-    const msgs: Message[] = []
+    const msgs: Text[] = []
     let out = ''
     for (const m of ctx.content.matchAll(/'\w+'/g)) {
         const msg = m[0].slice(1, -1)
@@ -83,10 +84,10 @@ export const dummyTransform: TransformFunc = ctx => {
             continue
         }
         out += `${ctx.expr.plain}(${ctx.index.get(msg)})\n`
-        msgs.push(newMessage({ msgStr: [msg] }))
+        msgs.push(newText({ body: [msg] }))
     }
     return {
-        msgs,
+        txts: msgs,
         output: header => ({
             code: `${header}\n${out}`,
             map: [],


### PR DESCRIPTION
The current context in `Message.details` works most of the time, but it doesn't provide full context, like ignoring the whole sub-tree of an ignored element (#408). This changes the whole concept and provides a `Text.path` that is an array of different context scope objects indicating the nesting chain, so that the heuristic can make more informed decisions.