### PR TITLE
fix: resolve.ts redirects wrong /src/ segment on nested checkouts

### DIFF
--- a/packages/wuchale/testing/resolve.ts
+++ b/packages/wuchale/testing/resolve.ts
@@ -5,16 +5,26 @@
  */
 
 import { registerHooks } from 'node:module'
-import { dirname, resolve as pathResolve, sep } from 'node:path'
+import { basename, dirname, resolve as pathResolve, relative, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const thisDir = dirname(fileURLToPath(import.meta.url))
 
-function srcToDist(path: string): string {
-    const marker = `${sep}src${sep}`
-    const idx = path.lastIndexOf(marker)
-    if (idx === -1) return path
-    return `${path.slice(0, idx)}${sep}dist${sep}${path.slice(idx + marker.length)}`
+function findPackageRoot(parentDir: string): string | null {
+    if (parentDir === thisDir) return dirname(parentDir)
+    for (let dir = parentDir; ; ) {
+        if (basename(dir) === 'src') return dirname(dir)
+        const parent = dirname(dir)
+        if (parent === dir) return null
+        dir = parent
+    }
+}
+
+function srcToDist(path: string, packageRoot: string): string {
+    const rel = relative(packageRoot, path)
+    const marker = `src${sep}`
+    if (!rel.startsWith(marker)) return path
+    return pathResolve(packageRoot, `dist${sep}${rel.slice(marker.length)}`)
 }
 
 registerHooks({
@@ -29,11 +39,13 @@ registerHooks({
                 specifier.startsWith('.')
             ) {
                 const absoluteTarget = pathResolve(parentDir, specifier)
+                const packageRoot = findPackageRoot(parentDir)
                 if (
+                    packageRoot &&
                     (absoluteTarget.includes('/src/') || absoluteTarget.includes('\\src\\')) &&
                     absoluteTarget.endsWith('.js')
                 ) {
-                    const redirectedPath = srcToDist(absoluteTarget)
+                    const redirectedPath = srcToDist(absoluteTarget, packageRoot)
                     const newUrl = pathToFileURL(redirectedPath).href
                     return nextResolve(newUrl)
                 }

--- a/packages/wuchale/testing/resolve.ts
+++ b/packages/wuchale/testing/resolve.ts
@@ -5,10 +5,17 @@
  */
 
 import { registerHooks } from 'node:module'
-import { dirname, resolve as pathResolve } from 'node:path'
+import { dirname, resolve as pathResolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const thisDir = dirname(fileURLToPath(import.meta.url))
+
+function srcToDist(path: string): string {
+    const marker = `${sep}src${sep}`
+    const idx = path.lastIndexOf(marker)
+    if (idx === -1) return path
+    return `${path.slice(0, idx)}${sep}dist${sep}${path.slice(idx + marker.length)}`
+}
 
 registerHooks({
     resolve: (specifier, context, nextResolve) => {
@@ -26,7 +33,7 @@ registerHooks({
                     (absoluteTarget.includes('/src/') || absoluteTarget.includes('\\src\\')) &&
                     absoluteTarget.endsWith('.js')
                 ) {
-                    const redirectedPath = absoluteTarget.replace('/src/', '/dist/').replace('\\src\\', '\\dist\\')
+                    const redirectedPath = srcToDist(absoluteTarget)
                     const newUrl = pathToFileURL(redirectedPath).href
                     return nextResolve(newUrl)
                 }

--- a/packages/wuchale/testing/resolve.ts
+++ b/packages/wuchale/testing/resolve.ts
@@ -5,27 +5,13 @@
  */
 
 import { registerHooks } from 'node:module'
-import { basename, dirname, resolve as pathResolve, relative, sep } from 'node:path'
+import { dirname, resolve as pathResolve, sep } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
 const thisDir = dirname(fileURLToPath(import.meta.url))
-
-function findPackageRoot(parentDir: string): string | null {
-    if (parentDir === thisDir) return dirname(parentDir)
-    for (let dir = parentDir; ; ) {
-        if (basename(dir) === 'src') return dirname(dir)
-        const parent = dirname(dir)
-        if (parent === dir) return null
-        dir = parent
-    }
-}
-
-function srcToDist(path: string, packageRoot: string): string {
-    const rel = relative(packageRoot, path)
-    const marker = `src${sep}`
-    if (!rel.startsWith(marker)) return path
-    return pathResolve(packageRoot, `dist${sep}${rel.slice(marker.length)}`)
-}
+const findAfter = `${sep}wuchale${sep}packages${sep}`
+const distPatt = `${sep}dist${sep}`
+const srcPatt = `${sep}src${sep}`
 
 registerHooks({
     resolve: (specifier, context, nextResolve) => {
@@ -33,19 +19,19 @@ registerHooks({
         if (parentURL) {
             const parentPath = fileURLToPath(parentURL ?? '')
             const parentDir = dirname(parentPath)
+            const findAfterIs = specifier.indexOf(findAfter) + findAfter.length
+            const findAfterIu = parentURL.indexOf(findAfter) + findAfter.length
             if (
-                !(specifier.includes('/dist/') || specifier.includes('\\dist\\')) &&
-                (parentURL.includes('.test.') || parentDir === thisDir) &&
+                !specifier.includes(distPatt, findAfterIs) &&
+                (parentURL.includes('.test.', findAfterIu) || parentDir === thisDir) &&
                 specifier.startsWith('.')
             ) {
                 const absoluteTarget = pathResolve(parentDir, specifier)
-                const packageRoot = findPackageRoot(parentDir)
-                if (
-                    packageRoot &&
-                    (absoluteTarget.includes('/src/') || absoluteTarget.includes('\\src\\')) &&
-                    absoluteTarget.endsWith('.js')
-                ) {
-                    const redirectedPath = srcToDist(absoluteTarget, packageRoot)
+                const findAfterIt = absoluteTarget.indexOf(findAfter) + findAfter.length
+                if (absoluteTarget.includes(srcPatt, findAfterIt) && absoluteTarget.endsWith('.js')) {
+                    const redirectedPath =
+                        absoluteTarget.slice(0, findAfterIt) +
+                        absoluteTarget.slice(findAfterIt).replace(srcPatt, distPatt)
                     const newUrl = pathToFileURL(redirectedPath).href
                     return nextResolve(newUrl)
                 }


### PR DESCRIPTION
## Summary
- `testing/resolve.ts` redirected `.js` test imports to their compiled `dist` output by replacing the *first* `/src/` occurrence in the resolved path with `/dist/`.
- On a checkout whose path already contains `src` above the repo root (e.g. `~/src/wuchale`), that matched the wrong segment and produced a bogus, unresolvable path, breaking the entire test suite for anyone with that layout.
- Now targets the *last* `/src/` segment instead, which is always the one inside `packages/<pkg>/src/`.

Fixes #444

## Test plan
- [x] `tsc -b` clean build of the `wuchale` package
- [x] `npm run test` in `packages/wuchale` — 50/50 passing
- [x] Reproduced the original bug with a one-off script confirming `'/Users/x/src/wuchale/packages/wuchale/src/foo.js'.replace('/src/', '/dist/')` corrupts the path, and confirmed the fix resolves it correctly