### PR TITLE
fix: crash collecting assignment names from destructuring patterns

### DIFF
--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -3,14 +3,3 @@
 ---
 
 Fix crash when collecting assignment names from destructuring patterns
-
-`getAssignmentNames` was passed unbound to `flatMap`, so `this` was `undefined` in the
-callback and any pattern that recursed threw
-`TypeError: Cannot read properties of undefined (reading 'getAssignmentNames')`. This hit
-rest elements and nested patterns, e.g. the common
-`let { class: className, ...rest } = $props()`.
-
-Object patterns also silently resolved to no names, because `ObjectPattern.properties`
-yields `Property` nodes and there was no branch for them. They now recurse into
-`property.value`, so assignment targets (used by `ignoreAssign` and nested message naming)
-are resolved for destructured declarations.

--- a/.changeset/tall-moons-repeat.md
+++ b/.changeset/tall-moons-repeat.md
@@ -1,0 +1,16 @@
+---
+"wuchale": patch
+---
+
+Fix crash when collecting assignment names from destructuring patterns
+
+`getAssignmentNames` was passed unbound to `flatMap`, so `this` was `undefined` in the
+callback and any pattern that recursed threw
+`TypeError: Cannot read properties of undefined (reading 'getAssignmentNames')`. This hit
+rest elements and nested patterns, e.g. the common
+`let { class: className, ...rest } = $props()`.
+
+Object patterns also silently resolved to no names, because `ObjectPattern.properties`
+yields `Property` nodes and there was no branch for them. They now recurse into
+`property.value`, so assignment targets (used by `ignoreAssign` and nested message naming)
+are resolved for destructured declarations.

--- a/packages/wuchale/src/adapter-vanilla/transformer.test.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.test.ts
@@ -6,6 +6,7 @@ import { transformTest, ts } from '../../testing/utils.ts'
 import { getFuncNameNested } from '../adapter-utils/index.js'
 import { IndexTracker, type RuntimeConf } from '../adapters.js'
 import { URLHandler } from '../handler/url.js'
+import { createHeuristic, defaultHeuristicOpts } from '../text.js'
 import { defaultArgs } from './index.js'
 import { Transformer } from './transformer.js'
 
@@ -326,5 +327,46 @@ test('Partial on read dev mode', t => {
             }
         `,
         ['Hello'], // no There! as it is new
+    )
+})
+
+test('Destructuring patterns in declarations', t => {
+    // rest elements and nested patterns must not throw while collecting assignment names
+    transformTest(
+        t,
+        getOutput(ts`
+            const { alpha, ...rest } = source
+            const [{ beta }] = source
+            const [...items] = source
+            const { gamma: { delta } } = source
+        `),
+        undefined,
+        [],
+    )
+})
+
+test('Object pattern names are collected as assignment targets', t => {
+    transformTest(
+        t,
+        new Transformer(
+            makeCtx(ts`
+                function foo() {
+                    const { ignored } = { msg: 'Hello' }
+                    const { kept } = { msg: 'There!' }
+                }
+            `),
+            createHeuristic({ ...defaultHeuristicOpts, ignoreAssign: ['ignored'] }),
+            defaultArgs.patterns,
+            defaultArgs.runtime,
+        ).transform(),
+        ts`
+            import { _w_load_, _w_load_rx_ } from "./loader.js"
+            function foo() {
+                const { ignored } = { msg: 'Hello' }
+                const _w_runtime_ = _w_load_();
+                const { kept } = { msg: _w_runtime_(0) }
+            }
+        `,
+        ['There!'], // no Hello as its target is ignored
     )
 })

--- a/packages/wuchale/src/adapter-vanilla/transformer.test.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.test.ts
@@ -6,7 +6,6 @@ import { transformTest, ts } from '../../testing/utils.ts'
 import { getFuncNameNested } from '../adapter-utils/index.js'
 import { IndexTracker, type RuntimeConf } from '../adapters.js'
 import { URLHandler } from '../handler/url.js'
-import { createHeuristic, defaultHeuristicOpts } from '../text.js'
 import { defaultArgs } from './index.js'
 import { Transformer } from './transformer.js'
 
@@ -22,8 +21,15 @@ const makeCtx = (content: string, index = new IndexTracker(true)) => ({
     matchUrl: urlHandler.match,
 })
 
-const getOutput = (content: string, patterns = defaultArgs.patterns) =>
-    new Transformer(makeCtx(content), defaultArgs.heuristic, patterns, defaultArgs.runtime).transform()
+const getOutput = (content: string, patterns = defaultArgs.patterns) => {
+    return new Transformer(
+        makeCtx(content),
+        ({ path }) =>
+            path.some(s => s.type === 'assignment' && !s.left && s.targets.includes('ignored')) ? false : undefined,
+        patterns,
+        defaultArgs.runtime,
+    ).transform()
+}
 
 test('Simple expression and assignment', t => {
     transformTest(
@@ -331,42 +337,22 @@ test('Partial on read dev mode', t => {
 })
 
 test('Destructuring patterns in declarations', t => {
-    // rest elements and nested patterns must not throw while collecting assignment names
     transformTest(
         t,
         getOutput(ts`
-            const { alpha, ...rest } = source
-            const [{ beta }] = source
-            const [...items] = source
-            const { gamma: { delta } } = source
+            function foo() {
+                const { a: [ ignored ], ...rest } = { a: ['Hello'] }
+                const { kept } = { msg: 'There!' }
+            }
         `),
-        undefined,
-        [],
-    )
-})
-
-test('Object pattern names are collected as assignment targets', t => {
-    transformTest(
-        t,
-        new Transformer(
-            makeCtx(ts`
-                function foo() {
-                    const { ignored } = { msg: 'Hello' }
-                    const { kept } = { msg: 'There!' }
-                }
-            `),
-            createHeuristic({ ...defaultHeuristicOpts, ignoreAssign: ['ignored'] }),
-            defaultArgs.patterns,
-            defaultArgs.runtime,
-        ).transform(),
         ts`
             import { _w_load_, _w_load_rx_ } from "./loader.js"
             function foo() {
-                const { ignored } = { msg: 'Hello' }
+                const { a: [ ignored ], ...rest } = { a: ['Hello'] }
                 const _w_runtime_ = _w_load_();
                 const { kept } = { msg: _w_runtime_(0) }
             }
         `,
-        ['There!'], // no Hello as its target is ignored
+        ['There!'],
     )
 })

--- a/packages/wuchale/src/adapter-vanilla/transformer.ts
+++ b/packages/wuchale/src/adapter-vanilla/transformer.ts
@@ -485,9 +485,11 @@ export class Transformer extends InertVisitors {
         if (id.type === 'Identifier') {
             names.push(id.name)
         } else if (id.type === 'ArrayPattern') {
-            names = id.elements.filter(n => n !== null).flatMap(this.getAssignmentNames)
+            names = id.elements.filter(n => n !== null).flatMap(n => this.getAssignmentNames(n))
         } else if (id.type === 'ObjectPattern') {
-            names = id.properties.flatMap(this.getAssignmentNames)
+            names = id.properties.flatMap(n => this.getAssignmentNames(n))
+        } else if (id.type === 'Property') {
+            names = this.getAssignmentNames(id.value)
         } else if (id.type === 'RestElement') {
             names = this.getAssignmentNames(id.argument)
         } else if (id.type === 'AssignmentPattern') {


### PR DESCRIPTION
`getAssignmentNames` was passed unbound to `flatMap`, so `this` was undefined inside the callback. Any pattern reaching a branch that recurses — rest elements, nested object/array patterns, defaults inside arrays, member expressions — threw:

  TypeError: Cannot read properties of undefined (reading 'getAssignmentNames')

This made `let { class: className, ...rest } = $props()` fail to transform, which is the standard Svelte 5 / bits-ui component idiom.

Object patterns were also silently resolving to no names at all: `ObjectPattern.properties` yields ESTree `Property` nodes and there was no branch handling them, so they fell through to `[]`. The signature already declared `Estree.AssignmentProperty` as valid input. Added a `Property` branch that recurses into `property.value`, so assignment targets are populated for destructured declarations — these feed `ignoreAssign` and nested message naming.

Both behaviours are covered by regression tests.