### PR TITLE
fix: do not wrap {@const} declarations in $derived

### DIFF
--- a/.changeset/olive-donuts-shake.md
+++ b/.changeset/olive-donuts-shake.md
@@ -1,0 +1,12 @@
+---
+"@wuchale/svelte": patch
+---
+
+Fix `{@const}` being wrapped in `$derived`, producing invalid Svelte
+
+Translated `{@const}` declarations were emitted as `{@const x = $derived(...)}`, which
+Svelte rejects with
+[`state_invalid_placement`](https://svelte.dev/e/state_invalid_placement). `{@const}` is
+already re-evaluated along with its enclosing block, so it never needs the wrapper.
+
+`{let}` and `{const}` declaration tags are still wrapped as before.

--- a/.changeset/olive-donuts-shake.md
+++ b/.changeset/olive-donuts-shake.md
@@ -2,11 +2,4 @@
 "@wuchale/svelte": patch
 ---
 
-Fix `{@const}` being wrapped in `$derived`, producing invalid Svelte
-
-Translated `{@const}` declarations were emitted as `{@const x = $derived(...)}`, which
-Svelte rejects with
-[`state_invalid_placement`](https://svelte.dev/e/state_invalid_placement). `{@const}` is
-already re-evaluated along with its enclosing block, so it never needs the wrapper.
-
-`{let}` and `{const}` declaration tags are still wrapped as before.
+Fix `{@const}` being wrapped in `$derived` after new text scope logic

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -580,3 +580,27 @@ test('Mixed attribute', async t => {
         ['{0} at {1} pixels'],
     )
 })
+
+test('Const tag is not wrapped in $derived', async t => {
+    transformTest(
+        t,
+        await getOutput(svelte`
+        {#if show}
+            {@const label = 'Hello'}
+            <span>{label}</span>
+        {/if}
+        `),
+        svelte`
+        <script>
+            import { _w_load_, _w_load_rx_ } from "./loader.js"
+            import W_tx_ from "@wuchale/svelte/runtime.svelte"
+            const _w_runtime_ = $derived(_w_load_rx_());
+        </script>
+        {#if show}
+            {@const label = _w_runtime_(0)}
+            <span>{label}</span>
+        {/if}
+    `,
+        ['Hello'],
+    )
+})

--- a/packages/svelte/src/transformer.test.ts
+++ b/packages/svelte/src/transformer.test.ts
@@ -397,6 +397,7 @@ test('Tags and directives', async t => {
         await getOutput(svelte`
             {@render foo('Hello')}
             {@html 'Hello'}
+            {@const a = 'Hello'}
             {let x = 'Hello'}
             <form on:submit|preventDefault>
                 {const y = $derived('Hello')}
@@ -411,13 +412,14 @@ test('Tags and directives', async t => {
         </script>
             {@render foo(_w_runtime_(0))}
             {@html _w_runtime_(0)}
+            {@const a = _w_runtime_(0)}
             {let x = $derived(_w_runtime_(0))}
             <form on:submit|preventDefault>
                 {const y = $derived(_w_runtime_(0))}
                 <button on:click={() => alert(_w_runtime_(0))}>42</button>
             </form>
     `,
-        ['Hello', 'Hello', 'Hello', 'Hello', 'Hello'],
+        ['Hello', 'Hello', 'Hello', 'Hello', 'Hello', 'Hello'],
     )
 })
 
@@ -578,29 +580,5 @@ test('Mixed attribute', async t => {
         <img alt={_w_runtime_(0, [name, width])} />
         `,
         ['{0} at {1} pixels'],
-    )
-})
-
-test('Const tag is not wrapped in $derived', async t => {
-    transformTest(
-        t,
-        await getOutput(svelte`
-        {#if show}
-            {@const label = 'Hello'}
-            <span>{label}</span>
-        {/if}
-        `),
-        svelte`
-        <script>
-            import { _w_load_, _w_load_rx_ } from "./loader.js"
-            import W_tx_ from "@wuchale/svelte/runtime.svelte"
-            const _w_runtime_ = $derived(_w_load_rx_());
-        </script>
-        {#if show}
-            {@const label = _w_runtime_(0)}
-            <span>{label}</span>
-        {/if}
-    `,
-        ['Hello'],
     )
 })

--- a/packages/svelte/src/transformer.ts
+++ b/packages/svelte/src/transformer.ts
@@ -38,6 +38,7 @@ export type RuntimeCtxSv = {
 export class SvelteTransformer extends Transformer {
     // state
     currentSnippet = 0
+    inConstTag = false
     moduleExportExprs: AnyNode[] = [] // to choose which runtime var to use for snippets
     override runtimeCtx: RuntimeCtxSv = { module: false }
 
@@ -72,7 +73,9 @@ export class SvelteTransformer extends Transformer {
             return true
         })
         const init = node.init
-        if (!needsWrapping || init == null) {
+        // `{@const}` is re-evaluated by Svelte along with its block, and Svelte rejects
+        // `$derived` there, so it must never be wrapped
+        if (!needsWrapping || init == null || this.inConstTag) {
             return txts
         }
         const isExported = this.moduleExportExprs.some(node => init.start >= node.start && init.end <= node.end)
@@ -206,8 +209,12 @@ export class SvelteTransformer extends Transformer {
     }
 
     visitConstTag(node: AST.ConstTag): Text[] {
+        const prevInConstTag = this.inConstTag
+        this.inConstTag = true
         // @ts-expect-error
-        return this.visitVariableDeclaration(node.declaration)
+        const txts = this.visitVariableDeclaration(node.declaration)
+        this.inConstTag = prevInConstTag
+        return txts
     }
 
     visitDeclarationTag(node: AST.DeclarationTag): Text[] {


### PR DESCRIPTION
Translated `{@const}` tags were emitted as:

  {@const label = $derived(_w_runtime_(0))}

which Svelte rejects with `state_invalid_placement` — `$derived` is only valid as a variable declaration initializer, a class field, or the first assignment to a class field in a constructor.

Before the `needsWrapping` rewrite, `visitDeclarationTag` opted in by setting `declaring = 'variable'` while `visitConstTag` deliberately did not, and the wrapping check gated on that. The rewrite replaced the `declaring` mechanism with a scope-path walk and the const-tag exclusion was dropped with it, so `{@const}` started being wrapped.

`{@const}` is re-evaluated by Svelte along with its enclosing block, so it does not need `$derived` to stay reactive. `{let}` and `{const}` declaration tags are unaffected and still wrapped, as covered by the existing "Tags and directives" test.