### PR TITLE
fix: create the generated dir before writing the dev pid file

### DIFF
--- a/.changeset/olive-pugs-search.md
+++ b/.changeset/olive-pugs-search.md
@@ -3,8 +3,3 @@
 ---
 
 Fix first build failing when the generated dir doesn't exist yet
-
-`Hub.create` wrote the dev pid file before `initGenDirWithData` created the directory it
-lives in, so a build on a tree without `{localesDir}/.wuchale` (which is gitignored, so
-any fresh clone or CI checkout) failed with
-`ENOENT: no such file or directory, open '.../.wuchale/dev.pid'`.

--- a/.changeset/olive-pugs-search.md
+++ b/.changeset/olive-pugs-search.md
@@ -1,0 +1,10 @@
+---
+"wuchale": patch
+---
+
+Fix first build failing when the generated dir doesn't exist yet
+
+`Hub.create` wrote the dev pid file before `initGenDirWithData` created the directory it
+lives in, so a build on a tree without `{localesDir}/.wuchale` (which is gitignored, so
+any fresh clone or CI checkout) failed with
+`ENOENT: no such file or directory, open '.../.wuchale/dev.pid'`.

--- a/packages/wuchale/src/hub.test.ts
+++ b/packages/wuchale/src/hub.test.ts
@@ -6,7 +6,6 @@ import { type TestContext, test } from 'node:test'
 import { inMemFS, regexTransform, trimLines, ts } from '../../wuchale/testing/utils.ts'
 import { defaultArgs } from './adapter-vanilla/index.js'
 import { type Config, defaultConfig } from './config.js'
-import type { FS } from './fs.js'
 import { generatedDir, normalizeSep } from './handler/files.js'
 import { devPidFile, Hub } from './hub.js'
 import { pluralTemplPath } from './plurals.js'
@@ -149,33 +148,4 @@ test('different dev modes', async (t: TestContext) => {
     poContent = (await inMemFS.read(po)) ?? ''
     t.assert.match(poContent, /"Hello"/)
     t.assert.doesNotMatch(poContent, /"Hello1"/)
-})
-
-test('hub creates the generated dir before writing the pid file', async (t: TestContext) => {
-    // like the real fs, writing into a directory that was never created fails
-    const files = new Map<string, string>()
-    // the locales dir is committed; only the generated dir inside it is gitignored
-    const dirs = new Set([normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir))])
-    const strictFS: FS = {
-        mkdir: path => {
-            dirs.add(normalizeSep(path))
-        },
-        write: (file, data) => {
-            const dir = normalizeSep(file).split('/').slice(0, -1).join('/')
-            if (!dirs.has(dir)) {
-                const err: NodeJS.ErrnoException = new Error(`ENOENT: no such file or directory, open '${file}'`)
-                err.code = 'ENOENT'
-                throw err
-            }
-            files.set(file, data)
-        },
-        read: file => files.get(file) ?? null,
-        exists: file => files.has(file),
-        unlink: file => files.delete(file),
-    }
-    files.set(defaultLoaderPath.client, '')
-    files.set(defaultLoaderPath.server, '')
-    files.set(pluralTemplPath, 'const ALL_C = []')
-    await t.assert.doesNotReject(() => Hub.create('dev', config, import.meta.dirname, [], 0, strictFS))
-    t.assert.ok(files.has(devPidPath), 'pid file written into the generated dir')
 })

--- a/packages/wuchale/src/hub.test.ts
+++ b/packages/wuchale/src/hub.test.ts
@@ -6,6 +6,7 @@ import { type TestContext, test } from 'node:test'
 import { inMemFS, regexTransform, trimLines, ts } from '../../wuchale/testing/utils.ts'
 import { defaultArgs } from './adapter-vanilla/index.js'
 import { type Config, defaultConfig } from './config.js'
+import type { FS } from './fs.js'
 import { generatedDir, normalizeSep } from './handler/files.js'
 import { devPidFile, Hub } from './hub.js'
 import { pluralTemplPath } from './plurals.js'
@@ -148,4 +149,33 @@ test('different dev modes', async (t: TestContext) => {
     poContent = (await inMemFS.read(po)) ?? ''
     t.assert.match(poContent, /"Hello"/)
     t.assert.doesNotMatch(poContent, /"Hello1"/)
+})
+
+test('hub creates the generated dir before writing the pid file', async (t: TestContext) => {
+    // like the real fs, writing into a directory that was never created fails
+    const files = new Map<string, string>()
+    // the locales dir is committed; only the generated dir inside it is gitignored
+    const dirs = new Set([normalizeSep(resolve(import.meta.dirname, defaultConfig.localesDir))])
+    const strictFS: FS = {
+        mkdir: path => {
+            dirs.add(normalizeSep(path))
+        },
+        write: (file, data) => {
+            const dir = normalizeSep(file).split('/').slice(0, -1).join('/')
+            if (!dirs.has(dir)) {
+                const err: NodeJS.ErrnoException = new Error(`ENOENT: no such file or directory, open '${file}'`)
+                err.code = 'ENOENT'
+                throw err
+            }
+            files.set(file, data)
+        },
+        read: file => files.get(file) ?? null,
+        exists: file => files.has(file),
+        unlink: file => files.delete(file),
+    }
+    files.set(defaultLoaderPath.client, '')
+    files.set(defaultLoaderPath.server, '')
+    files.set(pluralTemplPath, 'const ALL_C = []')
+    await t.assert.doesNotReject(() => Hub.create('dev', config, import.meta.dirname, [], 0, strictFS))
+    t.assert.ok(files.has(devPidPath), 'pid file written into the generated dir')
 })

--- a/packages/wuchale/src/hub.ts
+++ b/packages/wuchale/src/hub.ts
@@ -225,11 +225,12 @@ export class Hub {
         }
         const log = new Logger(config.logLevel)
         const pidFileAbs = resolve(root, config.localesDir, generatedDir, devPidFile)
+        // has to come first: it creates the generated dir that the pid file lives in
+        await initGenDirWithData(config, fs, root)
         const primary = await processIsPrimary(mode, fs, pidFileAbs)
         if (!primary) {
             log.warn(logPrefix, 'running in secondary process')
         }
-        await initGenDirWithData(config, fs, root)
         const sharedStates = new Map<string, SharedState>()
         const handlers = new Map<string, AdapterHandler>()
         const commonOpts = { config, mode, fs, root, log }


### PR DESCRIPTION
## Problem

The first build on a tree without `{localesDir}/.wuchale` fails:

```
[plugin wuchale] Error: ENOENT: no such file or directory,
open 'src/locales/.wuchale/dev.pid'
```

That directory is gitignored, so this hits every fresh clone and every CI checkout. The build only succeeds if some earlier run already created the directory.

Reproduced on `wuchale@0.26.2` with a minimal Vite + Svelte project — no `src/locales` at all, as on a fresh checkout:

```
published 0.26.2:  FAILED -> ENOENT ... '.wuchale/dev.pid'
this branch:       OK
```

## Cause

In `Hub.create`, `processIsPrimary` — which writes the pid file — runs before `initGenDirWithData`, which creates the directory the pid file lives in:

```ts
const pidFileAbs = resolve(root, config.localesDir, generatedDir, devPidFile)
const primary = await processIsPrimary(mode, fs, pidFileAbs)   // writes dev.pid
if (!primary) {
    log.warn(logPrefix, 'running in secondary process')
}
await initGenDirWithData(config, fs, root)                     // mkdirs the dir
```

`fs.read` routes through `handleEnoent`, so reading a missing pid file is fine — but `fs.write` calls `writeFile` directly and throws.

## Fix

Move `initGenDirWithData` above the pid check. It already ran unconditionally immediately afterwards and takes no `primary` argument, so nothing else changes.

## Test

The existing `inMemFS` has a no-op `mkdir` and a `write` that never fails, so it can't catch this. The regression test uses an FS that models the real constraint — writing into a directory that was never created throws `ENOENT` — with the locales dir seeded as present and the generated dir absent, matching a fresh checkout.

Verified red/green: without the fix the test reproduces the exact `ENOENT ... .wuchale/dev.pid`; with it, all 51 tests in the package pass, and `npm run check` is green across all workspaces.