### PR TITLE
feat: add wuchale-add scaffold CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -689,6 +689,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1722,6 +1723,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -1793,6 +1795,10 @@
             "resolved": "packages/wuchale",
             "link": true
         },
+        "node_modules/wuchale-add": {
+            "resolved": "packages/wuchale-add",
+            "link": true
+        },
         "node_modules/zimmerframe": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
@@ -1856,7 +1862,7 @@
         },
         "packages/svelte": {
             "name": "@wuchale/svelte",
-            "version": "0.20.4",
+            "version": "0.20.5",
             "license": "MIT",
             "dependencies": {
                 "wuchale": "^0.25.6"
@@ -1893,6 +1899,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/K1DV5"
+            }
+        },
+        "packages/wuchale-add": {
+            "version": "0.0.1",
+            "license": "MIT",
+            "bin": {
+                "wuchale-add": "dist/index.js"
+            },
+            "devDependencies": {
+                "@types/node": "~24.13.2",
+                "typescript": "^6.0.3"
             }
         },
         "packages/wuchale/node_modules/picomatch": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -45,7 +45,7 @@
             "default": "./src/runtime.svelte"
         },
         "./scaffold": {
-            "default": "./src/scaffold.js"
+            "default": "./dist/scaffold.js"
         }
     },
     "repository": {

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -43,6 +43,9 @@
         "./runtime.svelte": {
             "types": "./src/runtime.d.ts",
             "default": "./src/runtime.svelte"
+        },
+        "./scaffold": {
+            "default": "./src/scaffold.js"
         }
     },
     "repository": {

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -61,26 +61,10 @@ function scaffoldSvelteKit(ext: string, locale: string) {
     writeFileSync(hooksFile.file, transformHooksFile(hooksFile, locale))
 
     if (!existsSync(layoutFile.file)) {
-        writeFileSync(layoutFile.file, generateLayoutConfig(layoutFile.isTs, locale))
+        writeFileSync(layoutFile.file, '')
     }
-}
 
-function generateLayoutConfig(isTs: boolean, locale: string): string {
-    return `${isTs ? "import type { LayoutLoad } from './$types'" : ''}
-import '../locales/js.loader.js'
-import '../locales/svelte.loader.svelte.js'
-import { loadLocale } from 'wuchale/load-utils'
-import { browser } from '$app/environment'
-import { locales, type Locale } from '../locales/data.js'
-
-
-export const load${isTs ? ': LayoutLoad' : ''} = async ({url}) => {
-    const locale = url.searchParams.get('locale') ?? '${locale}'
-    if (browser && locales.includes(locale ${isTs ? 'as Locale' : ''})) {
-        await loadLocale(locale)
-    }
-}
-`
+    writeFileSync(layoutFile.file, transformLayoutFile(layoutFile, locale))
 }
 
 function transformHooksFile(hooksFile: { file: string; isTs: boolean }, locale: string): string {
@@ -124,11 +108,11 @@ function transformHooksFile(hooksFile: { file: string; isTs: boolean }, locale: 
     }
 
     if (!content.includes('loadLocales(svelte.key')) {
-        s.append('\nloadLocales(svelte.key, svelte.loadIDs, svelte.loadCatalog, locales)')
+        s.append('\nloadLocales(svelte.key, svelte.loadCount, svelte.loadCatalog, locales)')
     }
 
     if (!content.includes('loadLocales(js.key')) {
-        s.append('\nloadLocales(js.key, js.loadIDs, js.loadCatalog, locales)\n')
+        s.append('\nloadLocales(js.key, js.loadCount, js.loadCatalog, locales)\n')
     }
 
     const handleNode = findHandleNode(ast)
@@ -187,6 +171,117 @@ function transformHooksFile(hooksFile: { file: string; isTs: boolean }, locale: 
     return s.toString()
 }
 
+function transformLayoutFile(layoutFile: { file: string; isTs: boolean }, locale: string): string {
+    const content = readFileSync(layoutFile.file, 'utf8')
+    const ast = parser.parse(content, { ecmaVersion: 'latest', sourceType: 'module' })
+    const s = new MagicString(content)
+
+    const lastImportEnd = getLastImportEnd(ast)
+    isFirstImport = lastImportEnd !== 0
+    const imports = [
+        {
+            imports: `{ ${layoutFile.isTs ? 'type Locale, ' : ''}locales }`,
+            from: '../locales/data.js',
+        },
+        {
+            imports: '{ browser }',
+            from: '$app/environment',
+        },
+        {
+            imports: '{ loadLocale }',
+            from: 'wuchale/load-utils',
+        },
+        {
+            from: '../locales/js.loader.js',
+        },
+        {
+            from: '../locales/svelte.loader.svelte.js',
+        },
+    ]
+
+    if (layoutFile.isTs) {
+        imports.push({
+            imports: 'type { LayoutLoad }',
+            from: './$types',
+        })
+    }
+
+    for (const impt of imports) {
+        addImport(ast, s, lastImportEnd, impt)
+    }
+
+    const loadNode = ast.body.find(node => {
+        if (node.type !== 'ExportNamedDeclaration') return undefined
+
+        if (node.declaration?.type === 'VariableDeclaration') {
+            return node.declaration.declarations.some((d: any) => d.id?.name === 'load')
+        }
+
+        return undefined
+    }) as any
+
+    if (!loadNode) {
+        s.append(`export const load${layoutFile.isTs ? ': LayoutLoad' : ''} = async ({url}) => {
+    const locale = url.searchParams.get('locale') ?? '${locale}'
+    if (browser && locales.includes(locale ${layoutFile.isTs ? 'as Locale' : ''})) {
+        await loadLocale(locale)
+    }
+}`)
+    } else {
+        const loadDeclaration = loadNode.declaration.declarations.find((node: any) => {
+            if (node.id.name === 'load') return node
+            return undefined
+        })
+
+        if (layoutFile.isTs && !content.includes(': LayoutLoad')) {
+            s.appendRight(loadDeclaration.id.end, ': LayoutLoad')
+        }
+        const loadParameters = loadDeclaration.init.params
+        let argsStart: number
+
+        if (loadParameters.length > 0) {
+            argsStart = loadParameters[0].start
+        } else {
+            const arrowStart = content.indexOf('=>', loadDeclaration.init.start)
+            argsStart = content.lastIndexOf('(', arrowStart)
+            argsStart++
+        }
+
+        let hasUrl: boolean = false
+
+        if (!loadParameters || loadParameters.length === 0) {
+            s.appendRight(argsStart, '{ url }')
+            hasUrl = true
+        }
+
+        for (const param of loadParameters) {
+            for (const prop of param.properties) {
+                if (prop.key.name === 'url') {
+                    hasUrl = true
+                    break
+                }
+            }
+            if (hasUrl) break
+        }
+
+        if (!hasUrl) {
+            s.appendLeft(++argsStart, ` url,`)
+        }
+
+        const block = loadDeclaration.init.body
+
+        if (!content.includes('const locale = url.searchParams.get')) {
+            const localeDecl = `\nconst locale = url.searchParams.get('locale') ?? '${locale}';\n`
+            const ifStatement = `if (browser && locales.includes(locale ${
+                layoutFile.isTs ? 'as Locale' : ''
+            })) { await loadLocale(locale); }\n`
+            s.appendRight(++block.start, `${localeDecl}${ifStatement}`)
+        }
+    }
+
+    return s.toString()
+}
+
 function getLastImportEnd(ast: Program): number {
     for (const [i, node] of ast.body.entries()) {
         if (node.type === 'ImportDeclaration' && ast.body[i + 1]?.type !== 'ImportDeclaration') {
@@ -196,7 +291,7 @@ function getLastImportEnd(ast: Program): number {
     return 0
 }
 
-function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { imports: string; from: string }) {
+function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { imports?: string; from: string }) {
     let imptFound = false
     for (const node of ast.body) {
         if (node.type === 'ImportDeclaration') {
@@ -207,7 +302,10 @@ function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { 
     }
 
     if (!imptFound) {
-        s.appendLeft(lastImportEnd, `${isFirstImport ? '\n' : ''}import ${impt.imports} from '${impt.from}'\n`)
+        s.appendLeft(
+            lastImportEnd,
+            `${isFirstImport ? '\n' : ''}import ${impt.imports ? `${impt.imports} from ` : ''}'${impt.from}'\n`,
+        )
         isFirstImport = false
     }
 }
@@ -262,8 +360,8 @@ function generateTailwind(isKit: boolean) {
 
     const content = readFileSync(stylesheetFile, 'utf8')
 
-    if (!content.includes('@source not "../locales/";')) {
-        const newContent = `@source not "../locales/"\n${content}`
+    if (!content.includes('@source not "../locales/"')) {
+        const newContent = `@source not "../locales/"\n${content};`
         writeFileSync(stylesheetFile, newContent)
     }
 }

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -1,0 +1,132 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import MagicString from 'magic-string'
+
+interface DetectProjectResult {
+    packages: {
+        kind: string
+        adapter: string
+        choosable: boolean
+    }[]
+    hasTailwind: boolean
+    isTypeScript: boolean
+}
+
+interface ScaffoldContext {
+    project: DetectProjectResult
+    locales: string[]
+}
+
+export async function scaffold(ctx: ScaffoldContext) {
+    const isKit = ctx.project.packages.some(p => p.kind === 'sveltekit')
+    const locale = ctx.locales[0] ?? 'en'
+    const hasTailcss = ctx.project.hasTailwind
+    const ext = ctx.project.isTypeScript ? 'ts' : 'js'
+
+    if (isKit) {
+        scaffoldSvelteKit(ext, locale)
+    } else {
+        // scaffoldPlainSvelte(isTs, ext, hasTailcss, locale)
+    }
+
+    if (hasTailcss) {
+        generateTailwind(isKit)
+    }
+}
+
+// SvelteKit transformations
+
+function scaffoldSvelteKit(ext: string, locale: string) {
+    const hooksFile = resolveFile('src/hooks.server', ext)
+    const layoutFile = resolveFile('src/routes/+layout', ext)
+
+    if (!existsSync('src')) {
+        mkdirSync('src')
+    }
+
+    if (!existsSync('src/routes')) {
+        mkdirSync('src/routes')
+    }
+
+    if (!existsSync(hooksFile.file)) {
+        writeFileSync(hooksFile.file, generateHooksConfig(hooksFile.isTs, locale))
+    }
+
+    if (!existsSync(layoutFile.file)) {
+        writeFileSync(layoutFile.file, generateLayoutConfig(layoutFile.isTs, locale))
+    }
+}
+
+function generateHooksConfig(isTs: boolean, locale: string): string {
+    return `
+import * as svelte from './locales/svelte.loader.server.svelte.js'
+import * as js from './locales/js.loader.server.js'
+import { runWithLocale, loadLocales } from 'wuchale/load-utils/server';
+import { locales } from './locales/data.js'
+${isTs ? "import type { Handle } from '@sveltejs/kit';" : ''}
+
+loadLocales(svelte.key, svelte.loadCount, svelte.loadCatalog, locales)
+loadLocales(js.key, js.loadCount, js.loadCatalog, locales)
+
+export const handle ${isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
+    const locale = event.url.searchParams.get('locale') ?? '${locale}'
+    return await runWithLocale(locale, () => resolve(event))
+}
+`
+}
+
+function generateLayoutConfig(isTs: boolean, locale: string): string {
+    return `
+${isTs ? "import type { LayoutLoad } from './$types';" : ''}
+import '../locales/js.loader.js';
+import '../locales/svelte.loader.svelte.js';
+import { loadLocale } from 'wuchale/load-utils';
+import { browser } from '$app/environment';
+import { locales, type Locale } from '../locales/data.js';
+
+
+export const load${isTs ? ': LayoutLoad' : ''} = async ({url}) => {
+    const locale = url.searchParams.get('locale') ?? '${locale}'
+    if (browser && locales.includes(locale ${isTs ? 'as Locale' : ''})) {
+        await loadLocale(locale)
+    }
+}
+`
+}
+
+// Plain Svelte transformations
+// function scaffoldPlainSvelte(isTs: boolean, ext: string, hasTailcss: boolean, locale: string) {}
+
+// Tailwind
+function generateTailwind(isKit: boolean) {
+    let stylesheetFile: string | undefined
+
+    if (existsSync('src/routes/layout.css')) {
+        stylesheetFile = 'src/routes/layout.css'
+    } else if (existsSync('src/app.css')) {
+        stylesheetFile = 'src/app.css'
+    }
+
+    if (!stylesheetFile) {
+        stylesheetFile = isKit ? 'src/routes/layout.css' : 'src/app.css'
+    }
+
+    const content = readFileSync(stylesheetFile, 'utf8')
+
+    if (!content.includes('@source not "../locales/";')) {
+        const newContent = `@source not "../locales/"\n${content}`
+        writeFileSync(stylesheetFile, newContent)
+    }
+}
+
+// Utils
+//
+function resolveFile(file: string, ext: string): { file: string; isTs: boolean } {
+    if (existsSync(path.resolve(`${file}.ts`))) {
+        return { file: `${file}.ts`, isTs: true }
+    } else if (existsSync(path.resolve(`${file}.js`))) {
+        return { file: `${file}.js`, isTs: false }
+    } else {
+        return { file: `${file}.${ext}`, isTs: ext === 'ts' }
+    }
+}

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { tsPlugin } from '@sveltejs/acorn-typescript'
 import { type Node, Parser, type Program } from 'acorn'
 import MagicString from 'magic-string'
-import { type AST, compile, compileModule, parse, print } from 'svelte/compiler'
+import { type AST, parse, print } from 'svelte/compiler'
 
 interface DetectProjectResult {
     packages: Packages[]

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -58,8 +58,7 @@ function scaffoldSvelteKit(ext: string, locale: string) {
 }
 
 function generateHooksConfig(isTs: boolean, locale: string): string {
-    return `
-import * as svelte from './locales/svelte.loader.server.svelte.js'
+    return `import * as svelte from './locales/svelte.loader.server.svelte.js'
 import * as js from './locales/js.loader.server.js'
 import { runWithLocale, loadLocales } from 'wuchale/load-utils/server';
 import { locales } from './locales/data.js'
@@ -68,7 +67,7 @@ ${isTs ? "import type { Handle } from '@sveltejs/kit';" : ''}
 loadLocales(svelte.key, svelte.loadCount, svelte.loadCatalog, locales)
 loadLocales(js.key, js.loadCount, js.loadCatalog, locales)
 
-export const handle ${isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
+export const handle${isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
     const locale = event.url.searchParams.get('locale') ?? '${locale}'
     return await runWithLocale(locale, () => resolve(event))
 }
@@ -76,8 +75,7 @@ export const handle ${isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
 }
 
 function generateLayoutConfig(isTs: boolean, locale: string): string {
-    return `
-${isTs ? "import type { LayoutLoad } from './$types';" : ''}
+    return `${isTs ? "import type { LayoutLoad } from './$types';" : ''}
 import '../locales/js.loader.js';
 import '../locales/svelte.loader.svelte.js';
 import { loadLocale } from 'wuchale/load-utils';

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -1,6 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import path from 'node:path'
+import { tsPlugin } from '@sveltejs/acorn-typescript'
+import { type Node, Parser, type Program } from 'acorn'
 import MagicString from 'magic-string'
+import { type AST, parse } from 'svelte/compiler'
 
 interface DetectProjectResult {
     packages: {
@@ -16,6 +19,9 @@ interface ScaffoldContext {
     project: DetectProjectResult
     locales: string[]
 }
+
+const parser = Parser.extend(tsPlugin())
+let isFirstImport = true
 
 export async function scaffold(ctx: ScaffoldContext) {
     const isKit = ctx.project.packages.some(p => p.kind === 'sveltekit')
@@ -49,38 +55,23 @@ function scaffoldSvelteKit(ext: string, locale: string) {
     }
 
     if (!existsSync(hooksFile.file)) {
-        writeFileSync(hooksFile.file, generateHooksConfig(hooksFile.isTs, locale))
+        writeFileSync(hooksFile.file, '')
     }
+
+    writeFileSync(hooksFile.file, transformHooksFile(hooksFile, locale))
 
     if (!existsSync(layoutFile.file)) {
         writeFileSync(layoutFile.file, generateLayoutConfig(layoutFile.isTs, locale))
     }
 }
 
-function generateHooksConfig(isTs: boolean, locale: string): string {
-    return `import * as svelte from './locales/svelte.loader.server.svelte.js'
-import * as js from './locales/js.loader.server.js'
-import { runWithLocale, loadLocales } from 'wuchale/load-utils/server';
-import { locales } from './locales/data.js'
-${isTs ? "import type { Handle } from '@sveltejs/kit';" : ''}
-
-loadLocales(svelte.key, svelte.loadCount, svelte.loadCatalog, locales)
-loadLocales(js.key, js.loadCount, js.loadCatalog, locales)
-
-export const handle${isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
-    const locale = event.url.searchParams.get('locale') ?? '${locale}'
-    return await runWithLocale(locale, () => resolve(event))
-}
-`
-}
-
 function generateLayoutConfig(isTs: boolean, locale: string): string {
-    return `${isTs ? "import type { LayoutLoad } from './$types';" : ''}
-import '../locales/js.loader.js';
-import '../locales/svelte.loader.svelte.js';
-import { loadLocale } from 'wuchale/load-utils';
-import { browser } from '$app/environment';
-import { locales, type Locale } from '../locales/data.js';
+    return `${isTs ? "import type { LayoutLoad } from './$types'" : ''}
+import '../locales/js.loader.js'
+import '../locales/svelte.loader.svelte.js'
+import { loadLocale } from 'wuchale/load-utils'
+import { browser } from '$app/environment'
+import { locales, type Locale } from '../locales/data.js'
 
 
 export const load${isTs ? ': LayoutLoad' : ''} = async ({url}) => {
@@ -90,6 +81,166 @@ export const load${isTs ? ': LayoutLoad' : ''} = async ({url}) => {
     }
 }
 `
+}
+
+function transformHooksFile(hooksFile: { file: string; isTs: boolean }, locale: string): string {
+    const content = readFileSync(hooksFile.file, 'utf8')
+    const ast = parser.parse(content, {
+        sourceType: 'module',
+        ecmaVersion: 'latest',
+    })
+    const s = new MagicString(content)
+
+    const lastImportEnd = getLastImportEnd(ast)
+    isFirstImport = lastImportEnd !== 0
+    const imports = [
+        {
+            imports: '* as svelte',
+            from: './locales/svelte.loader.server.svelte.js',
+        },
+        {
+            imports: '* as js',
+            from: './locales/js.loader.server.js',
+        },
+        {
+            imports: '{ runWithLocale, loadLocales }',
+            from: 'wuchale/load-utils/server',
+        },
+        {
+            imports: '{ locales }',
+            from: './locales/data.js',
+        },
+    ]
+
+    if (hooksFile.isTs) {
+        imports.push({
+            imports: 'type { Handle }',
+            from: '@sveltejs/kit',
+        })
+    }
+
+    for (const impt of imports) {
+        addImport(ast, s, lastImportEnd, impt)
+    }
+
+    if (!content.includes('loadLocales(svelte.key')) {
+        s.append('\nloadLocales(svelte.key, svelte.loadIDs, svelte.loadCatalog, locales)')
+    }
+
+    if (!content.includes('loadLocales(js.key')) {
+        s.append('\nloadLocales(js.key, js.loadIDs, js.loadCatalog, locales)\n')
+    }
+
+    const handleNode = findHandleNode(ast)
+    const sequenceNode = findSequenceNode(ast)
+    const handleName = handleNode || sequenceNode ? 'i18n' : 'handle'
+
+    if (handleNode && !content.includes('await runWithLocale')) {
+        s.replace(/\bexport\b\s+(async\s+)?function\s+handle\b/g, '$1function handler')
+        s.replace(/\bexport\b\s+const\s+handle\b/g, 'const handler')
+    }
+
+    if (!content.includes('export const i18n') && !content.includes('await runWithLocale')) {
+        s.append(`\n${handleNode ? '' : 'export '}const ${handleName}${hooksFile.isTs ? ': Handle' : ''} = async ({ event, resolve }) => {
+    const locale = event.url.searchParams.get('locale') ?? '${locale}'
+    return await runWithLocale(locale, () => resolve(event))
+}\n`)
+    }
+
+    if (
+        !sequenceNode &&
+        handleNode &&
+        !content.includes('sequence(handler') &&
+        !content.includes('await runWithLocale')
+    ) {
+        addImport(ast, s, lastImportEnd, {
+            from: '@sveltejs/kit/hooks',
+            imports: '{ sequence }',
+        })
+
+        s.append('\nexport const handle = sequence(handler, i18n)')
+    }
+
+    if (sequenceNode) {
+        const sequenceArgs = sequenceNode.declaration?.declarations?.[0]?.init.arguments
+        const hasI18nArg = sequenceArgs.some((arg: any) => arg.type === 'Identifier' && arg.name === 'i18n')
+        if (!hasI18nArg) {
+            sequenceArgs.push({
+                type: 'Identifier',
+                name: 'i18n',
+                start: 0,
+                end: 0,
+            })
+        }
+
+        const argNames = sequenceArgs.map((arg: any) => arg.name).join(', ')
+
+        const index = ast.body.indexOf(sequenceNode)
+        ast.body.splice(index, 1)
+
+        s.replace(
+            /\bexport\s+const\s+handle\s+=\s+sequence\s*\([^)]*\)/g,
+            `export const handle = sequence(${argNames})`,
+        )
+    }
+
+    return s.toString()
+}
+
+function getLastImportEnd(ast: Program): number {
+    for (const [i, node] of ast.body.entries()) {
+        if (node.type === 'ImportDeclaration' && ast.body[i + 1]?.type !== 'ImportDeclaration') {
+            return node.end
+        }
+    }
+    return 0
+}
+
+function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { imports: string; from: string }) {
+    let imptFound = false
+    for (const node of ast.body) {
+        if (node.type === 'ImportDeclaration') {
+            if (node.source.value === impt.from) {
+                imptFound = true
+            }
+        }
+    }
+
+    if (!imptFound) {
+        s.appendLeft(lastImportEnd, `${isFirstImport ? '\n' : ''}import ${impt.imports} from '${impt.from}'\n`)
+        isFirstImport = false
+    }
+}
+
+function findHandleNode(ast: Program) {
+    return ast.body.find((node: any) => {
+        if (node.type !== 'ExportNamedDeclaration') return undefined
+
+        if (node.declaration?.type === 'VariableDeclaration') {
+            return node.declaration.declarations.find(
+                (d: any) => d.id?.name === 'handle' && d.init?.callee?.name !== 'sequence',
+            )
+        }
+
+        if (node.declaration?.type === 'FunctionDeclaration') {
+            return node.declaration.id.name === 'handle'
+        }
+
+        return undefined
+    }) as Node
+}
+
+function findSequenceNode(ast: Program) {
+    return ast.body.find((node: any) => {
+        if (node.type !== 'ExportNamedDeclaration') return false
+        if (node.declaration?.type === 'VariableDeclaration') {
+            return node.declaration?.declarations.some(
+                (d: any) =>
+                    d.id?.name === 'handle' && d.init?.type === 'CallExpression' && d.init?.callee?.name === 'sequence',
+            )
+        }
+        return false
+    }) as any
 }
 
 // Plain Svelte transformations

--- a/packages/svelte/src/scaffold.ts
+++ b/packages/svelte/src/scaffold.ts
@@ -3,16 +3,18 @@ import path from 'node:path'
 import { tsPlugin } from '@sveltejs/acorn-typescript'
 import { type Node, Parser, type Program } from 'acorn'
 import MagicString from 'magic-string'
-import { type AST, parse } from 'svelte/compiler'
+import { type AST, compile, compileModule, parse, print } from 'svelte/compiler'
 
 interface DetectProjectResult {
-    packages: {
-        kind: string
-        adapter: string
-        choosable: boolean
-    }[]
+    packages: Packages[]
     hasTailwind: boolean
     isTypeScript: boolean
+}
+
+interface Packages {
+    kind: string
+    adapter: string
+    choosable: boolean
 }
 
 interface ScaffoldContext {
@@ -32,7 +34,7 @@ export async function scaffold(ctx: ScaffoldContext) {
     if (isKit) {
         scaffoldSvelteKit(ext, locale)
     } else {
-        // scaffoldPlainSvelte(isTs, ext, hasTailcss, locale)
+        scaffoldPlainSvelte(locale, ctx.project.packages)
     }
 
     if (hasTailcss) {
@@ -282,34 +284,6 @@ function transformLayoutFile(layoutFile: { file: string; isTs: boolean }, locale
     return s.toString()
 }
 
-function getLastImportEnd(ast: Program): number {
-    for (const [i, node] of ast.body.entries()) {
-        if (node.type === 'ImportDeclaration' && ast.body[i + 1]?.type !== 'ImportDeclaration') {
-            return node.end
-        }
-    }
-    return 0
-}
-
-function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { imports?: string; from: string }) {
-    let imptFound = false
-    for (const node of ast.body) {
-        if (node.type === 'ImportDeclaration') {
-            if (node.source.value === impt.from) {
-                imptFound = true
-            }
-        }
-    }
-
-    if (!imptFound) {
-        s.appendLeft(
-            lastImportEnd,
-            `${isFirstImport ? '\n' : ''}import ${impt.imports ? `${impt.imports} from ` : ''}'${impt.from}'\n`,
-        )
-        isFirstImport = false
-    }
-}
-
 function findHandleNode(ast: Program) {
     return ast.body.find((node: any) => {
         if (node.type !== 'ExportNamedDeclaration') return undefined
@@ -341,8 +315,122 @@ function findSequenceNode(ast: Program) {
     }) as any
 }
 
+function getLastImportEnd(ast: Program): number {
+    for (const [i, node] of ast.body.entries()) {
+        if (node.type === 'ImportDeclaration' && ast.body[i + 1]?.type !== 'ImportDeclaration') {
+            return node.end
+        }
+    }
+    return 0
+}
+
+function addImport(ast: Program, s: MagicString, lastImportEnd: number, impt: { imports?: string; from: string }) {
+    let imptFound = false
+    for (const node of ast.body) {
+        if (node.type === 'ImportDeclaration') {
+            if (node.source.value === impt.from) {
+                imptFound = true
+            }
+        }
+    }
+
+    if (!imptFound) {
+        s.appendLeft(
+            lastImportEnd,
+            `${isFirstImport ? '\n' : ''}import ${impt.imports ? `${impt.imports} from ` : ''}'${impt.from}'\n`,
+        )
+        isFirstImport = false
+    }
+}
+
 // Plain Svelte transformations
-// function scaffoldPlainSvelte(isTs: boolean, ext: string, hasTailcss: boolean, locale: string) {}
+function scaffoldPlainSvelte(locale: string, packages: Packages[]) {
+    if (!existsSync('src')) {
+        mkdirSync('src')
+    }
+
+    if (!existsSync('src/App.svelte')) {
+        writeFileSync('src/App.svelte', '')
+    }
+
+    writeFileSync('src/App.svelte', transformPlainSvelte(locale, packages))
+}
+
+function transformPlainSvelte(locale: string, packages: Packages[]): string {
+    const content = readFileSync('src/App.svelte', 'utf8')
+    const ast = parse(content, { modern: true })
+    const imports = [
+        {
+            imports: '{ loadLocale }',
+            from: 'wuchale/load-utils',
+        },
+        {
+            from: `./locales/${packages.length > 1 ? 'svelte' : 'main'}.loader.svelte.js`,
+        },
+    ]
+
+    let scriptContentString = '<script>'
+
+    for (const impt of imports) {
+        const exists = checkImport(ast, impt)
+
+        if (!exists) {
+            scriptContentString += `import ${impt.imports ? `${impt.imports} from ` : ''}'${impt.from}'\n`
+        }
+    }
+    if (!content?.includes('let locale = $state')) {
+        scriptContentString += `let locale = $state('${locale}')`
+    }
+
+    scriptContentString += '</script>'
+
+    const injectedScript = parse(scriptContentString, { modern: true })
+    const injectedContent = injectedScript.instance?.content.body
+    if (injectedContent) ast.instance?.content.body.push(...injectedContent)
+
+    if (!content?.includes('#await loadLocale')) {
+        const nodes = ast.fragment.nodes
+
+        const existingHtml: string[] = []
+        for (const node of nodes) {
+            const element = content.slice(node.start, node.end)
+            existingHtml.push(element)
+        }
+
+        ast.fragment.nodes = []
+
+        const newHTML = `{#await loadLocale(locale)}
+            	<!-- Ignored because it is rendered before the catalog is loaded -->
+            	<!-- @wc-ignore -->
+        	Loading translations...
+        {:then}
+        ${existingHtml
+            .join('')
+            .split('\n')
+            .map(line => `\t${line}`)
+            .join('\n')}
+        {/await}`
+
+        const newHTMLParse = parse(newHTML, { modern: true })
+        const htmlBody = newHTMLParse.fragment.nodes
+        ast.fragment.nodes.push(...htmlBody)
+    }
+    return print(ast).code
+}
+
+function checkImport(ast: AST.Root, impt: { imports?: string; from: string }) {
+    let imptFound = false
+    const body = ast.instance?.content.body ?? []
+    for (const node of body) {
+        if (node.type === 'ImportDeclaration') {
+            if (node.source.value === impt.from) {
+                imptFound = true
+            }
+        }
+    }
+
+    return imptFound
+}
 
 // Tailwind
 function generateTailwind(isKit: boolean) {

--- a/packages/wuchale-add/package.json
+++ b/packages/wuchale-add/package.json
@@ -1,0 +1,55 @@
+{
+    "name": "wuchale-add",
+    "version": "0.0.1",
+    "description": "Protobuf-like i18n from plain code: Scaffold CLI",
+    "scripts": {
+        "dev": "tsc --watch",
+        "build": "tsc",
+        "test": "node --import ../wuchale/testing/resolve.ts --test"
+    },
+    "keywords": [
+        "i18n",
+        "internationalization",
+        "translation",
+        "gettext",
+        "vite",
+        "po",
+        "vite-plugin",
+        "compile-time",
+        "ast",
+        "translation-tooling",
+        "multilingual",
+        "localization",
+        "l10n",
+        "lingui",
+        "automatic-i18n",
+        "lightweight",
+        "scaffold",
+        "cli"
+    ],
+    "files": [
+        "dist"
+    ],
+    "bin": {
+        "wuchale-add": "./dist/index.js"
+    },
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "default": "./dist/index.js"
+        }
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wuchalejs/wuchale.git"
+    },
+    "homepage": "https://wuchale.dev",
+    "bugs": "https://github.com/wuchalejs/wuchale/issues",
+    "author": "K1DV5",
+    "license": "MIT",
+    "devDependencies": {
+        "@types/node": "~24.13.2",
+        "typescript": "^6.0.3"
+    },
+    "type": "module"
+}

--- a/packages/wuchale-add/src/config.ts
+++ b/packages/wuchale-add/src/config.ts
@@ -1,0 +1,100 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import type { AdapterConfig, DetectProjectResult, PairedAdapterConfig, ProjectKind } from './types.js'
+
+export function writeWuchaleConfig(project: DetectProjectResult, locales: string[]) {
+    if (project.hasWuchaleConfig) {
+        return
+    }
+
+    writeFileSync('./wuchale.config.js', generateConfigContent(project, locales), 'utf-8')
+}
+
+function generateConfigContent(project: DetectProjectResult, locales: string[]) {
+    const configs: AdapterConfig[] = []
+    for (const packageKind of project.packageKinds) {
+        if (project.projectKind === 'sveltekit' && packageKind === 'svelte') continue
+        configs.push(getAdapterConfig(packageKind, project.hasViteConfig))
+    }
+    let adapterConfigs = ''
+    let wuchaleConfigContent = '// @ts-check\n'
+
+    const pairedConfigs: PairedAdapterConfig[] = configs.flatMap(conf =>
+        conf.import.map((imp, index) => ({
+            import: imp,
+            content: conf.content[index]!,
+        })),
+    )
+
+    for (const [index, adapter] of pairedConfigs.entries()) {
+        const isLast = index === pairedConfigs.length - 1
+        const name = pairedConfigs.length > 1 ? adapter.import.name : 'main'
+        wuchaleConfigContent += `import { adapter as ${adapter.import.name} } from "${adapter.import.lib}"\n`
+        adapterConfigs += `${name}: ${adapter.content}${isLast ? '' : ',\n\t'}`
+    }
+
+    wuchaleConfigContent += `import { defineConfig } from "wuchale"\n
+export default defineConfig({
+    locales: [${locales.map(locale => `"${locale}"`).join(', ')}],
+    adapters: {
+	${adapterConfigs}
+    }
+})
+    `
+    return wuchaleConfigContent
+}
+
+function getAdapterConfig(project: ProjectKind, hasViteConfig: boolean): AdapterConfig {
+    switch (project) {
+        case 'react':
+            return {
+                import: [{ name: 'jsx', lib: '@wuchale/jsx' }],
+                content: ["jsx({ loader: 'react' })"],
+            }
+        case 'solid-js':
+            return {
+                import: [{ name: 'jsx', lib: '@wuchale/jsx' }],
+                content: [
+                    `jsx({
+\t\t    loader: 'solidjs',
+\t\t    variant: 'solidjs',
+\t})`,
+                ],
+            }
+        case 'svelte':
+            return {
+                import: [{ name: 'svelte', lib: '@wuchale/svelte' }],
+                content: ["svelte({ loader: 'svelte' })"],
+            }
+        case 'sveltekit':
+            return {
+                import: [
+                    { name: 'svelte', lib: '@wuchale/svelte' },
+                    { name: 'js', lib: 'wuchale/adapter-vanilla' },
+                ],
+                content: [
+                    "svelte({ loader: 'sveltekit' })",
+                    `js({
+    \t\tloader: 'vite',
+    \t\tfiles: [
+    \t\t    'src/**/+{page,layout}.{js,ts}',
+    \t\t    'src/**/+{page,layout}.server.{js,ts}',
+    \t\t],
+\t})`,
+                ],
+            }
+        case 'astro':
+            return {
+                import: [{ name: 'astro', lib: '@wuchale/astro' }],
+                content: ['astro()'],
+            }
+        case 'vanilla':
+            return {
+                import: [{ name: 'basic', lib: 'wuchale/adapter-vanilla' }],
+                content: [
+                    `basic({
+    \t\tloader: '${hasViteConfig ? 'vite' : 'default'}',
+\t})`,
+                ],
+            }
+    }
+}

--- a/packages/wuchale-add/src/config.ts
+++ b/packages/wuchale-add/src/config.ts
@@ -11,13 +11,16 @@ export function writeWuchaleConfig(project: DetectProjectResult, locales: string
 
 function generateConfigContent(project: DetectProjectResult, locales: string[]) {
     const configs: AdapterConfig[] = []
-    for (const packageKind of project.packageKinds) {
-        if (project.projectKind === 'sveltekit' && packageKind === 'svelte') continue
-        configs.push(getAdapterConfig(packageKind, project.hasViteConfig))
-    }
+
     let adapterConfigs = ''
     let wuchaleConfigContent = '// @ts-check\n'
 
+    for (const pkg of project.packages) {
+        if (project.packageOverrides[pkg.kind]) {
+            continue
+        }
+        configs.push(getAdapterConfig(pkg.kind, project.hasViteConfig))
+    }
     const pairedConfigs: PairedAdapterConfig[] = configs.flatMap(conf =>
         conf.import.map((imp, index) => ({
             import: imp,

--- a/packages/wuchale-add/src/config.ts
+++ b/packages/wuchale-add/src/config.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from 'node:fs'
+import { writeFileSync } from 'node:fs'
 import type { AdapterConfig, DetectProjectResult, PairedAdapterConfig, ProjectKind } from './types.js'
 
 export function writeWuchaleConfig(project: DetectProjectResult, locales: string[]) {

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -65,7 +65,9 @@ export function detectProject() {
             result.projectKind = fm.kind
             detectedPackages.push(fm.package)
             result.adapters.push(fm.adapter)
-            result.packageKinds.push(fm.kind)
+            if (fm.kind !== 'sveltekit') {
+                result.packageKinds.push(fm.kind)
+            }
             break
         }
     }

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -1,3 +1,93 @@
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
+import type { DetectProjectResult, ProjectKind } from './types.js'
 
-function readPackageJson() {}
+const metaFrameworks = [
+    {
+        package: '@sveltejs/kit',
+        adapter: '@wuchale/svelte',
+        kind: 'sveltekit',
+    },
+    {
+        package: 'astro',
+        adapter: '@wuchale/astro',
+        kind: 'astro',
+    },
+] satisfies { package: string; adapter: string; kind: ProjectKind }[]
+
+const frameworks = [
+    {
+        package: 'svelte',
+        adapter: '@wuchale/svelte',
+        kind: 'svelte',
+    },
+    {
+        package: 'react',
+        adapter: '@wuchale/jsx',
+        kind: 'react',
+    },
+    {
+        package: 'solid-js',
+        adapter: '@wuchale/jsx',
+        kind: 'solid-js',
+    },
+] satisfies { package: string; adapter: string; kind: ProjectKind }[]
+
+function readPackageJson() {
+    try {
+        const data = readFileSync('./package.json', 'utf-8')
+        return JSON.parse(data)
+    } catch {
+        return null
+    }
+}
+
+export function detectProject() {
+    const result: DetectProjectResult = {
+        projectKind: 'vanilla',
+        detectedPackages: [],
+        hasViteConfig: false,
+        hasWuchaleConfig: false,
+        isTypeScript: false,
+    }
+
+    const pkg = readPackageJson()
+    if (!pkg) return null
+
+    const detectedPackages: string[] = []
+
+    const deps: string[] = Object.keys(pkg.dependencies ?? {})
+    const devDeps = Object.keys(pkg.devDependencies ?? {})
+
+    for (const fm of metaFrameworks) {
+        if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
+            result.projectKind = fm.kind
+            detectedPackages.push(fm.package)
+            break
+        }
+    }
+
+    for (const fm of frameworks) {
+        if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
+            detectedPackages.push(fm.package)
+            if (result.projectKind === 'vanilla') {
+                result.projectKind = fm.kind
+            }
+        }
+    }
+
+    result.detectedPackages = detectedPackages
+
+    if (existsSync('vite.config.ts') || existsSync('vite.config.js')) {
+        result.hasViteConfig = true
+    }
+
+    if (existsSync('wuchale.config.ts') || existsSync('wuchale.config.js')) {
+        result.hasWuchaleConfig = true
+    }
+
+    if (deps.includes('typescript') || devDeps.includes('typescript')) {
+        result.isTypeScript = true
+    }
+
+    return result
+}

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -50,6 +50,7 @@ export function detectProject() {
         packages: [],
         packageOverrides: {},
         hasViteConfig: false,
+        hasTailwind: false,
         hasWuchaleConfig: false,
         isTypeScript: false,
     }
@@ -86,6 +87,10 @@ export function detectProject() {
 
     if (deps.includes('typescript') || devDeps.includes('typescript') || existsSync('tsconfig.json')) {
         result.isTypeScript = true
+    }
+
+    if (deps.includes('tailwindcss') || devDeps.includes('tailwindcss')) {
+        result.hasTailwind = true
     }
 
     return result

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'node:fs'
 import type { DetectProjectResult, ProjectKind } from './types.js'
 
 const metaFrameworks = [

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -45,6 +45,7 @@ export function detectProject() {
     const result: DetectProjectResult = {
         projectKind: 'vanilla',
         detectedPackages: [],
+        adapters: [],
         packageKinds: [],
         hasViteConfig: false,
         hasWuchaleConfig: false,
@@ -63,6 +64,7 @@ export function detectProject() {
         if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
             result.projectKind = fm.kind
             detectedPackages.push(fm.package)
+            result.adapters.push(fm.adapter)
             result.packageKinds.push(fm.kind)
             break
         }
@@ -72,6 +74,9 @@ export function detectProject() {
         if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
             detectedPackages.push(fm.package)
             result.packageKinds.push(fm.kind)
+            if (!result.adapters.includes(fm.adapter)) {
+                result.adapters.push(fm.adapter)
+            }
             if (result.projectKind === 'vanilla') {
                 result.projectKind = fm.kind
             }

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -1,0 +1,3 @@
+import { readFileSync } from 'fs'
+
+function readPackageJson() {}

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -45,6 +45,7 @@ export function detectProject() {
     const result: DetectProjectResult = {
         projectKind: 'vanilla',
         detectedPackages: [],
+        packageKinds: [],
         hasViteConfig: false,
         hasWuchaleConfig: false,
         isTypeScript: false,
@@ -62,6 +63,7 @@ export function detectProject() {
         if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
             result.projectKind = fm.kind
             detectedPackages.push(fm.package)
+            result.packageKinds.push(fm.kind)
             break
         }
     }
@@ -69,11 +71,14 @@ export function detectProject() {
     for (const fm of frameworks) {
         if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
             detectedPackages.push(fm.package)
+            result.packageKinds.push(fm.kind)
             if (result.projectKind === 'vanilla') {
                 result.projectKind = fm.kind
             }
         }
     }
+
+    if (result.packageKinds.length === 0) result.packageKinds.push('vanilla')
 
     result.detectedPackages = detectedPackages
 

--- a/packages/wuchale-add/src/detect.ts
+++ b/packages/wuchale-add/src/detect.ts
@@ -1,36 +1,40 @@
 import { existsSync, readFileSync } from 'node:fs'
-import type { DetectProjectResult, ProjectKind } from './types.js'
+import type { DetectProjectResult, FrameworkDefinition } from './types.js'
 
-const metaFrameworks = [
+const frameworks = [
     {
         package: '@sveltejs/kit',
         adapter: '@wuchale/svelte',
         kind: 'sveltekit',
+        choosable: false,
+        overrides: ['svelte'],
     },
     {
         package: 'astro',
         adapter: '@wuchale/astro',
+        choosable: true,
         kind: 'astro',
     },
-] satisfies { package: string; adapter: string; kind: ProjectKind }[]
 
-const frameworks = [
     {
         package: 'svelte',
         adapter: '@wuchale/svelte',
+        choosable: true,
         kind: 'svelte',
     },
     {
         package: 'react',
         adapter: '@wuchale/jsx',
+        choosable: true,
         kind: 'react',
     },
     {
         package: 'solid-js',
         adapter: '@wuchale/jsx',
+        choosable: true,
         kind: 'solid-js',
     },
-] satisfies { package: string; adapter: string; kind: ProjectKind }[]
+] satisfies FrameworkDefinition[]
 
 function readPackageJson() {
     try {
@@ -43,10 +47,8 @@ function readPackageJson() {
 
 export function detectProject() {
     const result: DetectProjectResult = {
-        projectKind: 'vanilla',
-        detectedPackages: [],
-        adapters: [],
-        packageKinds: [],
+        packages: [],
+        packageOverrides: {},
         hasViteConfig: false,
         hasWuchaleConfig: false,
         isTypeScript: false,
@@ -55,39 +57,24 @@ export function detectProject() {
     const pkg = readPackageJson()
     if (!pkg) return null
 
-    const detectedPackages: string[] = []
-
     const deps: string[] = Object.keys(pkg.dependencies ?? {})
     const devDeps = Object.keys(pkg.devDependencies ?? {})
 
-    for (const fm of metaFrameworks) {
-        if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
-            result.projectKind = fm.kind
-            detectedPackages.push(fm.package)
-            result.adapters.push(fm.adapter)
-            if (fm.kind !== 'sveltekit') {
-                result.packageKinds.push(fm.kind)
-            }
-            break
-        }
-    }
-
     for (const fm of frameworks) {
         if (deps.includes(fm.package) || devDeps.includes(fm.package)) {
-            detectedPackages.push(fm.package)
-            result.packageKinds.push(fm.kind)
-            if (!result.adapters.includes(fm.adapter)) {
-                result.adapters.push(fm.adapter)
-            }
-            if (result.projectKind === 'vanilla') {
-                result.projectKind = fm.kind
+            result.packages.push({
+                kind: fm.kind,
+                choosable: fm.choosable,
+                adapter: fm.adapter,
+            })
+
+            if (fm.overrides) {
+                for (const override of fm.overrides) {
+                    result.packageOverrides[override] = fm.kind
+                }
             }
         }
     }
-
-    if (result.packageKinds.length === 0) result.packageKinds.push('vanilla')
-
-    result.detectedPackages = detectedPackages
 
     if (existsSync('vite.config.ts') || existsSync('vite.config.js')) {
         result.hasViteConfig = true
@@ -97,7 +84,7 @@ export function detectProject() {
         result.hasWuchaleConfig = true
     }
 
-    if (deps.includes('typescript') || devDeps.includes('typescript')) {
+    if (deps.includes('typescript') || devDeps.includes('typescript') || existsSync('tsconfig.json')) {
         result.isTypeScript = true
     }
 

--- a/packages/wuchale-add/src/gitignore.ts
+++ b/packages/wuchale-add/src/gitignore.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 
 export function writeGitignore() {
     if (existsSync('.gitignore')) {

--- a/packages/wuchale-add/src/gitignore.ts
+++ b/packages/wuchale-add/src/gitignore.ts
@@ -1,0 +1,10 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+
+export function writeGitignore() {
+    if (existsSync('.gitignore')) {
+        let content = readFileSync('.gitignore', 'utf8')
+        if (content.includes('.wuchale')) return
+        content += '\n#Wuchale\n.wuchale\n'
+        writeFileSync('.gitignore', content, 'utf8')
+    }
+}

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -27,9 +27,13 @@ const zippedAdapters = project.adapters.map((adapter, index) => ({
     kind: project.packageKinds[index],
 }))
 
-const adapters = confirmedAdapters
-    .filter(adapt => adapt.checked)
-    .map(adapt => zippedAdapters.find(zipAdapt => zipAdapt.kind === adapt.name.toLowerCase())!.adapter)
+const adapters = [
+    ...new Set(
+        confirmedAdapters
+            .filter(adapt => adapt.checked)
+            .map(adapt => zippedAdapters.find(zipAdapt => zipAdapt.kind === adapt.name.toLowerCase())!.adapter),
+    ),
+]
 
 const shouldInstall = await confirmPrompt('Install selected dependencies + wuchale package?')
 

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -6,7 +6,7 @@ import { detectProject } from './detect.js'
 import { writeGitignore } from './gitignore.js'
 import { detectPackageManager, installDependencies } from './install.js'
 import { adapterMultiboxPrompt, confirmPrompt, languagesPrompt } from './prompts.js'
-import type { DetectProjectResult, MultiboxPromptOptions, PackageManager, ScaffoldModule } from './types.js'
+import type { DetectProjectResult, PackageManager, ScaffoldModule } from './types.js'
 import { writeViteConfig } from './vite.js'
 
 console.log(`Wuchale-add CLI ${pkg.version}`)
@@ -22,9 +22,11 @@ const locales = await languagesPrompt()
 
 const choosablePackages = project.packages.filter(pkg => pkg.choosable)
 
-const confirmedAdapters: MultiboxPromptOptions[] = await adapterMultiboxPrompt(choosablePackages)
+const confirmedAdapters = await adapterMultiboxPrompt(choosablePackages)
 
-const adapters = [...new Set(confirmedAdapters.filter(adapt => adapt.checked).map(pkg => pkg.adapter))]
+const selectedAdapters = confirmedAdapters.filter(adapt => adapt.checked)
+
+const adapters = selectedAdapters.map(pkg => pkg.adapter)
 
 const shouldInstall = await confirmPrompt('Install selected dependencies + wuchale package?')
 
@@ -54,10 +56,11 @@ if (shouldModifyFiles) {
         project,
         locales,
     }
-    for (const adapter of confirmedAdapters) {
+    const cwd = process.cwd()
+    const require = createRequire(`${cwd}/package.json`)
+
+    for (const adapter of selectedAdapters) {
         try {
-            const cwd = process.cwd()
-            const require = createRequire(`${cwd}/package.json`)
             const resolvedPath = require.resolve(`${adapter.adapter}/scaffold`)
             const module = (await import(resolvedPath)) as ScaffoldModule
             await module.scaffold(context)

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -1,2 +1,48 @@
 #!/usr/bin/env node
+import pkg from '../package.json' with { type: 'json' }
+import { writeWuchaleConfig } from './config.js'
+import { detectProject } from './detect.js'
+import { writeGitignore } from './gitignore.js'
+import { detectPackageManager, installDependencies } from './install.js'
+import { adapterMultiboxPrompt, confirmPrompt, languagesPrompt } from './prompts.js'
+import type { DetectProjectResult, MultiboxPromptOptions, PackageManager } from './types.js'
 
+console.log(`Wuchale-add CLI ${pkg.version}`)
+
+const project: DetectProjectResult | null = detectProject()
+
+if (!project) {
+    console.error('No package.json file found. Are you in a project directory?')
+    process.exit(1)
+}
+
+const locales = await languagesPrompt()
+
+const confirmedAdapters: MultiboxPromptOptions[] = await adapterMultiboxPrompt(project.packageKinds)
+const adapters = []
+for (const adapter of confirmedAdapters) {
+    adapters.push(adapter.name)
+}
+
+const shouldInstall = await confirmPrompt('Install selected dependencies?')
+
+if (shouldInstall) {
+    try {
+        await installDependencies(adapters)
+        console.log('Dependencies installed')
+    } catch (error) {
+        console.error(`${error} Try manually:`)
+        const pkgMgr: PackageManager = detectPackageManager()
+        console.error(`\t${pkgMgr.name} ${pkgMgr.install} wuchale ${adapters.join(' ')}`)
+    }
+}
+
+writeGitignore()
+writeWuchaleConfig(project, locales)
+// writeViteConfig() future vite config injection function
+
+const shouldModifyFiles = await confirmPrompt('Generate and inject example setup files?')
+
+if (shouldModifyFiles) {
+    // calling scaffolding module here
+}

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -6,15 +6,16 @@ import { detectProject } from './detect.js'
 import { writeGitignore } from './gitignore.js'
 import { detectPackageManager, installDependencies } from './install.js'
 import { adapterMultiboxPrompt, confirmPrompt, languagesPrompt } from './prompts.js'
+import { errorText, STYLE, style, successText } from './style.js'
 import type { DetectProjectResult, PackageManager, ScaffoldModule } from './types.js'
 import { writeViteConfig } from './vite.js'
 
-console.log(`Wuchale-add CLI ${pkg.version}`)
+console.log(style(`Wuchale-add CLI ${pkg.version}`, STYLE.BLUE, STYLE.BOLD))
 
 const project: DetectProjectResult | null = detectProject()
 
 if (!project) {
-    console.error('No package.json file found. Are you in a project directory?')
+    console.error(errorText('No package.json file found. Are you in a project directory?'))
     process.exit(1)
 }
 
@@ -36,11 +37,11 @@ if (shouldInstall) {
     } else {
         try {
             await installDependencies(adapters)
-            console.log('Dependencies installed')
+            console.log(successText('Dependencies installed'))
         } catch (error) {
-            console.error(`${error} Try manually:`)
+            console.error(errorText(`${error} Try manually:`))
             const pkgMgr: PackageManager = detectPackageManager()
-            console.error(`\t${pkgMgr.name} ${pkgMgr.install} wuchale ${adapters.join(' ')}`)
+            console.error(errorText(`\t${pkgMgr.name} ${pkgMgr.install} wuchale ${adapters.join(' ')}`))
         }
     }
 }
@@ -65,7 +66,9 @@ if (shouldModifyFiles) {
             const module = (await import(resolvedPath)) as ScaffoldModule
             await module.scaffold(context)
         } catch (err) {
-            console.log(`Failed to scaffold for ${adapter.adapter}: ${err}`)
+            console.log(errorText(`Failed to scaffold for ${adapter.adapter}: ${err}`))
         }
     }
 }
+
+console.log(style(`Done!`, STYLE.BLUE, STYLE.BOLD))

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -21,21 +21,30 @@ if (!project) {
 const locales = await languagesPrompt()
 
 const confirmedAdapters: MultiboxPromptOptions[] = await adapterMultiboxPrompt(project.packageKinds)
-const adapters = []
-for (const adapter of confirmedAdapters) {
-    adapters.push(adapter.name)
-}
 
-const shouldInstall = await confirmPrompt('Install selected dependencies?')
+const zippedAdapters = project.adapters.map((adapter, index) => ({
+    adapter: adapter,
+    kind: project.packageKinds[index],
+}))
+
+const adapters = confirmedAdapters
+    .filter(adapt => adapt.checked)
+    .map(adapt => zippedAdapters.find(zipAdapt => zipAdapt.kind === adapt.name.toLowerCase())!.adapter)
+
+const shouldInstall = await confirmPrompt('Install selected dependencies + wuchale package?')
 
 if (shouldInstall) {
-    try {
-        await installDependencies(adapters)
-        console.log('Dependencies installed')
-    } catch (error) {
-        console.error(`${error} Try manually:`)
-        const pkgMgr: PackageManager = detectPackageManager()
-        console.error(`\t${pkgMgr.name} ${pkgMgr.install} wuchale ${adapters.join(' ')}`)
+    if (adapters.length === 0) {
+        console.log('No dependencies to install')
+    } else {
+        try {
+            await installDependencies(adapters)
+            console.log('Dependencies installed')
+        } catch (error) {
+            console.error(`${error} Try manually:`)
+            const pkgMgr: PackageManager = detectPackageManager()
+            console.error(`\t${pkgMgr.name} ${pkgMgr.install} wuchale ${adapters.join(' ')}`)
+        }
     }
 }
 

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
+import { createRequire } from 'node:module'
 import pkg from '../package.json' with { type: 'json' }
 import { writeWuchaleConfig } from './config.js'
 import { detectProject } from './detect.js'
 import { writeGitignore } from './gitignore.js'
 import { detectPackageManager, installDependencies } from './install.js'
 import { adapterMultiboxPrompt, confirmPrompt, languagesPrompt } from './prompts.js'
-import type { DetectProjectResult, MultiboxPromptOptions, PackageManager } from './types.js'
+import type { DetectProjectResult, MultiboxPromptOptions, PackageManager, ScaffoldModule } from './types.js'
+import { writeViteConfig } from './vite.js'
 
 console.log(`Wuchale-add CLI ${pkg.version}`)
 
@@ -39,10 +41,24 @@ if (shouldInstall) {
 
 writeGitignore()
 writeWuchaleConfig(project, locales)
-// writeViteConfig() future vite config injection function
+writeViteConfig(project)
 
 const shouldModifyFiles = await confirmPrompt('Generate and inject example setup files?')
 
 if (shouldModifyFiles) {
-    // calling scaffolding module here
+    const context = {
+        project,
+        locales,
+    }
+    for (const adapter of project.adapters) {
+        try {
+            const cwd = process.cwd()
+            const require = createRequire(`${cwd}/package.json`)
+            const resolvedPath = require.resolve(`${adapter}/scaffold`)
+            const module = (await import(resolvedPath)) as ScaffoldModule
+            await module.scaffold(context)
+        } catch (err) {
+            console.log(`Failed to scaffold for ${adapter}: ${err}`)
+        }
+    }
 }

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -20,20 +20,11 @@ if (!project) {
 
 const locales = await languagesPrompt()
 
-const confirmedAdapters: MultiboxPromptOptions[] = await adapterMultiboxPrompt(project.packageKinds)
+const choosablePackages = project.packages.filter(pkg => pkg.choosable)
 
-const zippedAdapters = project.adapters.map((adapter, index) => ({
-    adapter: adapter,
-    kind: project.packageKinds[index],
-}))
+const confirmedAdapters: MultiboxPromptOptions[] = await adapterMultiboxPrompt(choosablePackages)
 
-const adapters = [
-    ...new Set(
-        confirmedAdapters
-            .filter(adapt => adapt.checked)
-            .map(adapt => zippedAdapters.find(zipAdapt => zipAdapt.kind === adapt.name.toLowerCase())!.adapter),
-    ),
-]
+const adapters = [...new Set(confirmedAdapters.filter(adapt => adapt.checked).map(pkg => pkg.adapter))]
 
 const shouldInstall = await confirmPrompt('Install selected dependencies + wuchale package?')
 
@@ -63,15 +54,15 @@ if (shouldModifyFiles) {
         project,
         locales,
     }
-    for (const adapter of project.adapters) {
+    for (const adapter of confirmedAdapters) {
         try {
             const cwd = process.cwd()
             const require = createRequire(`${cwd}/package.json`)
-            const resolvedPath = require.resolve(`${adapter}/scaffold`)
+            const resolvedPath = require.resolve(`${adapter.adapter}/scaffold`)
             const module = (await import(resolvedPath)) as ScaffoldModule
             await module.scaffold(context)
         } catch (err) {
-            console.log(`Failed to scaffold for ${adapter}: ${err}`)
+            console.log(`Failed to scaffold for ${adapter.adapter}: ${err}`)
         }
     }
 }

--- a/packages/wuchale-add/src/index.ts
+++ b/packages/wuchale-add/src/index.ts
@@ -71,4 +71,6 @@ if (shouldModifyFiles) {
     }
 }
 
-console.log(style(`Done!`, STYLE.BLUE, STYLE.BOLD))
+console.log(style(`Wuchale setup complete`, STYLE.BLUE, STYLE.BOLD))
+console.log(`Run ${style("'npx wuchale'", STYLE.COMMAND)} for initial extract`)
+console.log(`Visit the wuchale docs at ${style('https://wuchale.dev/', STYLE.WEBSITE)} for full configuration`)

--- a/packages/wuchale-add/src/install.ts
+++ b/packages/wuchale-add/src/install.ts
@@ -1,0 +1,26 @@
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import type { DetectProjectResult, PackageManager } from './types.js'
+
+export function installDependencies(project: DetectProjectResult): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const pkgManager: PackageManager = detectPackageManager()
+        const proc = spawn(pkgManager.name, [pkgManager.install, 'wuchale', ...project.adapters], {
+            stdio: 'inherit',
+        })
+
+        proc.on('error', reject)
+
+        proc.on('close', code => {
+            if (code === 0) resolve()
+            else reject(new Error('Failed to install dependencies'))
+        })
+    })
+}
+
+function detectPackageManager() {
+    if (existsSync('./pnpm-lock.yaml')) return { name: 'pnpm', install: 'add' }
+    else if (existsSync('./yarn.lock')) return { name: 'yarn', install: 'add' }
+    else if (existsSync('./bun.lock') || existsSync('./bun.lockb')) return { name: 'bun', install: 'add' }
+    return { name: 'npm', install: 'install' }
+}

--- a/packages/wuchale-add/src/install.ts
+++ b/packages/wuchale-add/src/install.ts
@@ -1,6 +1,6 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import type { DetectProjectResult, MultiboxPromptOptions, PackageManager } from './types.js'
+import type { PackageManager } from './types.js'
 
 export function installDependencies(adapters: string[]): Promise<void> {
     return new Promise((resolve, reject) => {

--- a/packages/wuchale-add/src/install.ts
+++ b/packages/wuchale-add/src/install.ts
@@ -1,11 +1,11 @@
 import { spawn } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import type { DetectProjectResult, PackageManager } from './types.js'
+import type { DetectProjectResult, MultiboxPromptOptions, PackageManager } from './types.js'
 
-export function installDependencies(project: DetectProjectResult): Promise<void> {
+export function installDependencies(adapters: string[]): Promise<void> {
     return new Promise((resolve, reject) => {
         const pkgManager: PackageManager = detectPackageManager()
-        const proc = spawn(pkgManager.name, [pkgManager.install, 'wuchale', ...project.adapters], {
+        const proc = spawn(pkgManager.name, [pkgManager.install, 'wuchale', ...adapters], {
             stdio: 'inherit',
         })
 
@@ -13,12 +13,12 @@ export function installDependencies(project: DetectProjectResult): Promise<void>
 
         proc.on('close', code => {
             if (code === 0) resolve()
-            else reject(new Error('Failed to install dependencies'))
+            else reject(new Error('Failed to install dependencies.'))
         })
     })
 }
 
-function detectPackageManager() {
+export function detectPackageManager(): PackageManager {
     if (existsSync('./pnpm-lock.yaml')) return { name: 'pnpm', install: 'add' }
     else if (existsSync('./yarn.lock')) return { name: 'yarn', install: 'add' }
     else if (existsSync('./bun.lock') || existsSync('./bun.lockb')) return { name: 'bun', install: 'add' }

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -1,4 +1,3 @@
-import { read } from 'node:fs'
 import readline from 'node:readline'
 import type { ProjectKind } from './types.js'
 
@@ -167,7 +166,7 @@ export function confirmPrompt(text: string) {
                     process.stdout.write('Operation cancelled\n')
                     return process.exit(0)
                 case '\r': {
-                    const isValid = input.toLowerCase() === 'y' || input.toLowerCase() === 'n' ? true : false
+                    const isValid = !!(input.toLowerCase() === 'y' || input.toLowerCase() === 'n')
                     if (!isValid) {
                         render('Not valid input')
                         return

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -14,8 +14,6 @@ const KEY = {
 const ANSI = {
     HIDE_CURSOR: '\x1b[?25l',
     SHOW_CURSOR: '\x1b[?25h',
-    RESTORE_CURSOR: '\x1b[u',
-    SAVE_CURSOR: '\x1b[s',
 }
 
 export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<MultiboxPromptOptions[]> {
@@ -112,19 +110,23 @@ export function languagesPrompt(): Promise<string[]> {
 
         const render = (error = '') => {
             if (rendered) {
-                process.stdout.write(ANSI.RESTORE_CURSOR)
-                readline.moveCursor(process.stdout, 0, -1)
+                const cursorLines = 1
+                readline.moveCursor(process.stdout, 0, -cursorLines)
+                readline.cursorTo(process.stdout, 0)
+
                 readline.clearScreenDown(process.stdout)
             }
 
             rendered = true
 
             process.stdout.write('Which languages do you want to support? (e.g. en,zh-TW)\n')
-            process.stdout.write(ANSI.SAVE_CURSOR)
 
-            process.stdout.write(`> ${input}`)
-            if (error) process.stdout.write(`\n${error}`)
+            process.stdout.write(`> ${input}\n`)
+            if (error) process.stdout.write(`${error}`)
+
             readline.cursorTo(process.stdout, input.length + 2)
+
+            readline.moveCursor(process.stdout, 0, -1)
         }
 
         const cleanup = () => {
@@ -157,6 +159,7 @@ export function languagesPrompt(): Promise<string[]> {
                     input = input.slice(0, -1)
                     break
                 default:
+                    if (key.startsWith('\u001b')) break
                     input += key
             }
 
@@ -180,15 +183,13 @@ export function confirmPrompt(text: string): Promise<boolean> {
 
         const render = (error = '') => {
             if (rendered) {
-                process.stdout.write(ANSI.RESTORE_CURSOR)
-                readline.moveCursor(process.stdout, 0, -1)
-
+                readline.cursorTo(process.stdout, 0)
+                readline.moveCursor(process.stdout, 0, 0)
                 readline.clearScreenDown(process.stdout)
             }
             rendered = true
 
             process.stdout.write(`${text}(Y/N): ${input}\n`)
-            process.stdout.write(ANSI.SAVE_CURSOR)
 
             if (error) process.stdout.write(`${error}`)
 
@@ -227,6 +228,7 @@ export function confirmPrompt(text: string): Promise<boolean> {
                     break
 
                 default:
+                    if (key.startsWith('\u001b')) break
                     input += key
             }
             render()

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -1,0 +1,180 @@
+import readline from 'node:readline'
+import type { ProjectKind } from './types.js'
+
+type MultiboxPromptOptions = {
+    name: string
+    checked: boolean
+}
+
+const displayName = new Intl.DisplayNames(['en'], { type: 'language' })
+
+export function adapterMultiboxPrompt(adapters: ProjectKind[]) {
+    return new Promise(resolve => {
+        const options: MultiboxPromptOptions[] = adapters.map(adapter => ({
+            name: adapter.charAt(0).toUpperCase() + adapter.slice(1),
+            checked: true,
+        }))
+        const lines = options.length + 1
+
+        const render = () => {
+            readline.moveCursor(process.stdout, 0, -lines)
+            readline.cursorTo(process.stdout, 0)
+            readline.clearScreenDown(process.stdout)
+
+            process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
+
+            options.forEach((option: MultiboxPromptOptions, index) => {
+                const pointer = index === cursor ? '<' : ''
+                const checked = option.checked ? '[x]' : '[]'
+
+                process.stdout.write(`${checked} ${option.name} ${pointer}\n`)
+            })
+        }
+
+        const cleanup = () => {
+            process.stdin.setRawMode(false)
+            process.stdin.pause()
+            process.stdin.off('data', onData)
+        }
+
+        const onData = (key: string) => {
+            switch (key) {
+                case '\u0003':
+                    process.stdin.write('Operation cancelled\n')
+                    return process.exit(0)
+
+                case '\r':
+                    cleanup()
+                    resolve(options)
+                    return
+
+                case ' ':
+                    options[cursor]!.checked = !options[cursor]?.checked
+                    break
+                case '\u001b[A':
+                    cursor = (cursor - 1 + options.length) % options.length
+                    break
+
+                case '\u001b[B':
+                    cursor = (cursor + 1) % options.length
+                    break
+            }
+            render()
+        }
+
+        let cursor = 0
+
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+        render()
+
+        process.stdin.on('data', onData)
+    })
+}
+
+export function languagesPrompt() {
+    return new Promise(resolve => {
+        let input = ''
+
+        const render = (error = '') => {
+            readline.cursorTo(process.stdout, 0)
+            readline.clearScreenDown(process.stdout)
+
+            const lines = ['Which languages do you want to support? (e.g. en,zh-TW)\n', `> ${input}\n`, error]
+            for (const line of lines) {
+                process.stdout.write(`${line}`)
+            }
+
+            readline.moveCursor(process.stdout, 0, -2)
+            readline.cursorTo(process.stdout, input.length + 2)
+            process.stdout.write('\x1b[s')
+        }
+
+        const cleanup = () => {
+            process.stdin.setRawMode(false)
+            process.stdin.pause()
+            process.stdin.off('data', onData)
+        }
+
+        const onData = (key: string) => {
+            switch (key) {
+                case '\u0003':
+                    cleanup()
+                    process.stdout.write('\nOperation cancelled\n')
+                    return process.exit(0)
+
+                case '\r': {
+                    const { invalidTags, validTags } = parseLanguageInput(input)
+
+                    if (invalidTags.length === 0) {
+                        cleanup()
+                        process.stdout.write('\n')
+                        resolve(validTags.length ? validTags : ['en'])
+                        return
+                    }
+
+                    render(checkInvalidTags(input) ?? undefined)
+                    return
+                }
+                case '\u007f':
+                    input = input.slice(0, -1)
+                    break
+                default:
+                    input += key
+            }
+
+            render()
+        }
+
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+
+        render()
+
+        process.stdin.on('data', onData)
+    })
+}
+
+function checkInvalidTags(data: string): string | undefined {
+    const { invalidTags } = parseLanguageInput(data)
+
+    if (invalidTags.length > 0) {
+        if (invalidTags.length === 1) {
+            return `Your input "${invalidTags[0]}" is not a valid BCP language tag`
+        } else {
+            const list = new Intl.ListFormat('en', {
+                style: 'long',
+                type: 'conjunction',
+            })
+            return `Your inputs ${list.format(invalidTags.map(x => `"${x}"`))} are not a valid BCP language tags`
+        }
+    }
+}
+
+function parseLanguageInput(input: string) {
+    const potentialTags = input.replace(/[,\s]/g, ' ').split(' ').filter(Boolean)
+
+    const validTags: string[] = []
+    const invalidTags: string[] = []
+
+    for (const tag of potentialTags) {
+        if (validLanguageTag(tag)) validTags.push(tag)
+        else invalidTags.push(tag)
+    }
+
+    return {
+        invalidTags,
+        validTags,
+    }
+}
+
+function validLanguageTag(tag: string) {
+    try {
+        const name = displayName.of(tag)
+        return name !== undefined && name !== tag
+    } catch {
+        return false
+    }
+}

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -9,13 +9,19 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
             name: adapter.charAt(0).toUpperCase() + adapter.slice(1),
             checked: true,
         }))
-        const lines = options.length + 1
+
+        let rendered = false
+        let cursor = 0
 
         const render = () => {
-            readline.moveCursor(process.stdout, 0, -lines)
-            readline.cursorTo(process.stdout, 0)
-            readline.clearScreenDown(process.stdout)
+            if (rendered) {
+                process.stdout.write('\x1b[u')
+                readline.clearScreenDown(process.stdout)
+            }
 
+            rendered = true
+            process.stdout.write('\x1b[s')
+            process.stdout.write('\x1b[?25l')
             process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
 
             options.forEach((option: MultiboxPromptOptions, index) => {
@@ -30,6 +36,7 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
             process.stdin.setRawMode(false)
             process.stdin.pause()
             process.stdin.off('data', onData)
+            process.stdout.write('\x1b[?25h')
         }
 
         const onData = (key: string) => {
@@ -57,8 +64,6 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
             render()
         }
 
-        let cursor = 0
-
         process.stdin.setRawMode(true)
         process.stdin.resume()
         process.stdin.setEncoding('utf8')
@@ -71,19 +76,22 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
 export function languagesPrompt(): Promise<string[]> {
     return new Promise(resolve => {
         let input = ''
+        let rendered = false
 
         const render = (error = '') => {
-            readline.cursorTo(process.stdout, 0)
-            readline.clearScreenDown(process.stdout)
-
-            const lines = ['Which languages do you want to support? (e.g. en,zh-TW)\n', `> ${input}\n`, error]
-            for (const line of lines) {
-                process.stdout.write(`${line}`)
+            if (rendered) {
+                process.stdout.write('\x1b[u')
+                readline.clearScreenDown(process.stdout)
             }
 
-            readline.moveCursor(process.stdout, 0, -2)
-            readline.cursorTo(process.stdout, input.length + 2)
+            rendered = true
             process.stdout.write('\x1b[s')
+
+            process.stdout.write('Which languages do you want to support? (e.g. en,zh-TW)\n')
+            process.stdout.write(`> ${input}\n`)
+            if (error) process.stdout.write(`${error}`)
+            readline.moveCursor(process.stdout, 0, -1)
+            readline.cursorTo(process.stdout, input.length + 2)
         }
 
         const cleanup = () => {
@@ -135,17 +143,22 @@ export function languagesPrompt(): Promise<string[]> {
 export function confirmPrompt(text: string): Promise<boolean> {
     return new Promise(resolve => {
         let input = ''
+        let rendered = false
 
         const render = (error = '') => {
-            readline.cursorTo(process.stdout, 0)
-            readline.clearScreenDown(process.stdout)
+            if (rendered) {
+                process.stdout.write('\x1b[u')
+                readline.clearScreenDown(process.stdout)
+            }
+
+            rendered = true
+            process.stdout.write('\x1b[s')
 
             process.stdout.write(`${text}(Y/N): ${input}\n`)
-            process.stdout.write(`${error}`)
+            if (error) process.stdout.write(`${error}`)
 
             readline.moveCursor(process.stdout, 0, -1)
             readline.cursorTo(process.stdout, text.length + input.length + 7)
-            process.stdin.write('\x1b[s')
         }
 
         const cleanup = () => {
@@ -169,6 +182,7 @@ export function confirmPrompt(text: string): Promise<boolean> {
 
                     if (input.toLowerCase() === 'y') resolve(true)
                     else resolve(false)
+                    process.stdout.write('\n')
                     cleanup()
                     return
                 }

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -20,11 +20,20 @@ const ANSI = {
 
 export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<MultiboxPromptOptions[]> {
     return new Promise(resolve => {
-        const options: MultiboxPromptOptions[] = packages.map(pkg => ({
-            name: pkg.kind.charAt(0).toUpperCase() + pkg.kind.slice(1),
-            adapter: pkg.adapter,
-            checked: true,
-        }))
+        const options = packages.reduce<MultiboxPromptOptions[]>((opts, pkg) => {
+            const name = pkg.kind.charAt(0).toUpperCase() + pkg.kind.slice(1)
+            const existing = opts.find(option => option.adapter === pkg.adapter)
+            if (existing) {
+                existing.name += `/${name}`
+            } else {
+                opts.push({
+                    name,
+                    adapter: pkg.adapter,
+                    checked: true,
+                })
+            }
+            return opts
+        }, [])
 
         if (options.length === 0) {
             resolve([])

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -15,16 +15,16 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
 
         const render = () => {
             if (rendered) {
-                process.stdout.write('\x1b[u')
+                const lines = options.length + 1
+                readline.moveCursor(process.stdout, 0, -lines)
                 readline.clearScreenDown(process.stdout)
             } else {
-                process.stdout.write('\x1b[s')
                 rendered = true
             }
 
             process.stdout.write('\x1b[?25l')
-            process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
 
+            process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
             options.forEach((option: MultiboxPromptOptions, index) => {
                 const pointer = index === cursor ? '<' : ''
                 const checked = option.checked ? '[x]' : '[]'

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -1,3 +1,4 @@
+import { read } from 'node:fs'
 import readline from 'node:readline'
 import type { ProjectKind } from './types.js'
 
@@ -124,6 +125,67 @@ export function languagesPrompt() {
                     input += key
             }
 
+            render()
+        }
+
+        process.stdin.setRawMode(true)
+        process.stdin.resume()
+        process.stdin.setEncoding('utf8')
+
+        render()
+
+        process.stdin.on('data', onData)
+    })
+}
+
+export function confirmPrompt(text: string) {
+    return new Promise(resolve => {
+        let input = ''
+
+        const render = (error = '') => {
+            readline.cursorTo(process.stdout, 0)
+            readline.clearScreenDown(process.stdout)
+
+            process.stdout.write(`${text}(Y/N): ${input}\n`)
+            process.stdout.write(`${error}`)
+
+            readline.moveCursor(process.stdout, 0, -1)
+            readline.cursorTo(process.stdout, text.length + input.length + 7)
+            process.stdin.write('\x1b[s')
+        }
+
+        const cleanup = () => {
+            process.stdin.setRawMode(false)
+            process.stdin.pause()
+            process.stdin.off('data', onData)
+        }
+
+        const onData = (key: string) => {
+            switch (key) {
+                case '\u0003':
+                    cleanup()
+                    process.stdout.write('Operation cancelled\n')
+                    return process.exit(0)
+                case '\r': {
+                    const isValid = input.toLowerCase() === 'y' || input.toLowerCase() === 'n' ? true : false
+                    if (!isValid) {
+                        render('Not valid input')
+                        return
+                    }
+
+                    if (input.toLowerCase() === 'y') resolve(true)
+                    else resolve(false)
+                    cleanup()
+                    return
+                }
+
+                case '\u007f':
+                    input = input.slice(0, -1)
+                    break
+
+                default:
+                    input += key
+            }
             render()
         }
 

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -3,6 +3,21 @@ import type { MultiboxPromptOptions, ProjectPackage } from './types.js'
 
 const displayName = new Intl.DisplayNames(['en'], { type: 'language' })
 
+const KEY = {
+    ENTER: '\r',
+    CTRL_C: '\u0003',
+    ARROW_UP: '\u001b[A',
+    ARROW_DOWN: '\u001b[B',
+    BACKSPACE: '\u007f',
+}
+
+const ANSI = {
+    HIDE_CURSOR: '\x1b[?25l',
+    SHOW_CURSOR: '\x1b[?25h',
+    RESTORE_CURSOR: '\x1b[u',
+    SAVE_CURSOR: '\x1b[s',
+}
+
 export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<MultiboxPromptOptions[]> {
     return new Promise(resolve => {
         const options: MultiboxPromptOptions[] = packages.map(pkg => ({
@@ -10,6 +25,11 @@ export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<Multi
             adapter: pkg.adapter,
             checked: true,
         }))
+
+        if (options.length === 0) {
+            resolve([])
+            return
+        }
 
         let rendered = false
         let cursor = 0
@@ -23,10 +43,10 @@ export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<Multi
                 rendered = true
             }
 
-            process.stdout.write('\x1b[?25l')
+            process.stdout.write(ANSI.HIDE_CURSOR)
 
             process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
-            options.forEach((option: MultiboxPromptOptions, index) => {
+            options.forEach((option, index) => {
                 const pointer = index === cursor ? '<' : ''
                 const checked = option.checked ? '[x]' : '[]'
 
@@ -38,17 +58,17 @@ export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<Multi
             process.stdin.setRawMode(false)
             process.stdin.pause()
             process.stdin.off('data', onData)
-            process.stdout.write('\x1b[?25h')
+            process.stdout.write(ANSI.SHOW_CURSOR)
         }
 
         const onData = (key: string) => {
             switch (key) {
-                case '\u0003':
+                case KEY.CTRL_C:
                     cleanup()
-                    process.stdin.write('Operation cancelled\n')
+                    process.stdout.write('Operation cancelled\n')
                     return process.exit(0)
 
-                case '\r':
+                case KEY.ENTER:
                     cleanup()
                     resolve(options)
                     return
@@ -56,11 +76,11 @@ export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<Multi
                 case ' ':
                     options[cursor]!.checked = !options[cursor]?.checked
                     break
-                case '\u001b[A':
+                case KEY.ARROW_UP:
                     cursor = (cursor - 1 + options.length) % options.length
                     break
 
-                case '\u001b[B':
+                case KEY.ARROW_DOWN:
                     cursor = (cursor + 1) % options.length
                     break
             }
@@ -83,7 +103,7 @@ export function languagesPrompt(): Promise<string[]> {
 
         const render = (error = '') => {
             if (rendered) {
-                process.stdout.write('\x1b[u')
+                process.stdout.write(ANSI.RESTORE_CURSOR)
                 readline.moveCursor(process.stdout, 0, -1)
                 readline.clearScreenDown(process.stdout)
             }
@@ -91,7 +111,7 @@ export function languagesPrompt(): Promise<string[]> {
             rendered = true
 
             process.stdout.write('Which languages do you want to support? (e.g. en,zh-TW)\n')
-            process.stdout.write('\x1b[s')
+            process.stdout.write(ANSI.SAVE_CURSOR)
 
             process.stdout.write(`> ${input}`)
             if (error) process.stdout.write(`\n${error}`)
@@ -106,12 +126,12 @@ export function languagesPrompt(): Promise<string[]> {
 
         const onData = (key: string) => {
             switch (key) {
-                case '\u0003':
+                case KEY.CTRL_C:
                     cleanup()
                     process.stdout.write('\nOperation cancelled\n')
                     return process.exit(0)
 
-                case '\r': {
+                case KEY.ENTER: {
                     const { invalidTags, validTags } = parseLanguageInput(input)
 
                     if (invalidTags.length === 0) {
@@ -124,7 +144,7 @@ export function languagesPrompt(): Promise<string[]> {
                     render(checkInvalidTags(input) ?? undefined)
                     return
                 }
-                case '\u007f':
+                case KEY.BACKSPACE:
                     input = input.slice(0, -1)
                     break
                 default:
@@ -151,7 +171,7 @@ export function confirmPrompt(text: string): Promise<boolean> {
 
         const render = (error = '') => {
             if (rendered) {
-                process.stdout.write('\x1b[u')
+                process.stdout.write(ANSI.RESTORE_CURSOR)
                 readline.moveCursor(process.stdout, 0, -1)
 
                 readline.clearScreenDown(process.stdout)
@@ -159,7 +179,7 @@ export function confirmPrompt(text: string): Promise<boolean> {
             rendered = true
 
             process.stdout.write(`${text}(Y/N): ${input}\n`)
-            process.stdout.write('\x1b[s')
+            process.stdout.write(ANSI.SAVE_CURSOR)
 
             if (error) process.stdout.write(`${error}`)
 
@@ -175,25 +195,25 @@ export function confirmPrompt(text: string): Promise<boolean> {
 
         const onData = (key: string) => {
             switch (key) {
-                case '\u0003':
+                case KEY.CTRL_C:
                     cleanup()
                     process.stdout.write('\nOperation cancelled\n')
                     return process.exit(0)
-                case '\r': {
-                    const isValid = !!(input.toLowerCase() === 'y' || input.toLowerCase() === 'n')
-                    if (!isValid) {
+                case KEY.ENTER: {
+                    const answer = input.toLowerCase()
+
+                    if (answer !== 'y' && answer !== 'n') {
                         render('Not valid input')
                         return
                     }
 
-                    if (input.toLowerCase() === 'y') resolve(true)
-                    else resolve(false)
+                    resolve(answer === 'y')
                     process.stdout.write('\n')
                     cleanup()
                     return
                 }
 
-                case '\u007f':
+                case KEY.BACKSPACE:
                     input = input.slice(0, -1)
                     break
 

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -1,12 +1,13 @@
 import readline from 'node:readline'
-import type { MultiboxPromptOptions, ProjectKind } from './types.js'
+import type { MultiboxPromptOptions, ProjectPackage } from './types.js'
 
 const displayName = new Intl.DisplayNames(['en'], { type: 'language' })
 
-export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<MultiboxPromptOptions[]> {
+export function adapterMultiboxPrompt(packages: ProjectPackage[]): Promise<MultiboxPromptOptions[]> {
     return new Promise(resolve => {
-        const options: MultiboxPromptOptions[] = adapters.map(adapter => ({
-            name: adapter.charAt(0).toUpperCase() + adapter.slice(1),
+        const options: MultiboxPromptOptions[] = packages.map(pkg => ({
+            name: pkg.kind.charAt(0).toUpperCase() + pkg.kind.slice(1),
+            adapter: pkg.adapter,
             checked: true,
         }))
 

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -1,14 +1,9 @@
 import readline from 'node:readline'
-import type { ProjectKind } from './types.js'
-
-type MultiboxPromptOptions = {
-    name: string
-    checked: boolean
-}
+import type { MultiboxPromptOptions, ProjectKind } from './types.js'
 
 const displayName = new Intl.DisplayNames(['en'], { type: 'language' })
 
-export function adapterMultiboxPrompt(adapters: ProjectKind[]) {
+export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<MultiboxPromptOptions[]> {
     return new Promise(resolve => {
         const options: MultiboxPromptOptions[] = adapters.map(adapter => ({
             name: adapter.charAt(0).toUpperCase() + adapter.slice(1),
@@ -73,7 +68,7 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]) {
     })
 }
 
-export function languagesPrompt() {
+export function languagesPrompt(): Promise<string[]> {
     return new Promise(resolve => {
         let input = ''
 
@@ -137,7 +132,7 @@ export function languagesPrompt() {
     })
 }
 
-export function confirmPrompt(text: string) {
+export function confirmPrompt(text: string): Promise<boolean> {
     return new Promise(resolve => {
         let input = ''
 

--- a/packages/wuchale-add/src/prompts.ts
+++ b/packages/wuchale-add/src/prompts.ts
@@ -17,10 +17,11 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
             if (rendered) {
                 process.stdout.write('\x1b[u')
                 readline.clearScreenDown(process.stdout)
+            } else {
+                process.stdout.write('\x1b[s')
+                rendered = true
             }
 
-            rendered = true
-            process.stdout.write('\x1b[s')
             process.stdout.write('\x1b[?25l')
             process.stdout.write('Detected adapters to install (Space = check/uncheck, Enter = accept)\n')
 
@@ -42,6 +43,7 @@ export function adapterMultiboxPrompt(adapters: ProjectKind[]): Promise<Multibox
         const onData = (key: string) => {
             switch (key) {
                 case '\u0003':
+                    cleanup()
                     process.stdin.write('Operation cancelled\n')
                     return process.exit(0)
 
@@ -81,16 +83,17 @@ export function languagesPrompt(): Promise<string[]> {
         const render = (error = '') => {
             if (rendered) {
                 process.stdout.write('\x1b[u')
+                readline.moveCursor(process.stdout, 0, -1)
                 readline.clearScreenDown(process.stdout)
             }
 
             rendered = true
-            process.stdout.write('\x1b[s')
 
             process.stdout.write('Which languages do you want to support? (e.g. en,zh-TW)\n')
-            process.stdout.write(`> ${input}\n`)
-            if (error) process.stdout.write(`${error}`)
-            readline.moveCursor(process.stdout, 0, -1)
+            process.stdout.write('\x1b[s')
+
+            process.stdout.write(`> ${input}`)
+            if (error) process.stdout.write(`\n${error}`)
             readline.cursorTo(process.stdout, input.length + 2)
         }
 
@@ -148,13 +151,15 @@ export function confirmPrompt(text: string): Promise<boolean> {
         const render = (error = '') => {
             if (rendered) {
                 process.stdout.write('\x1b[u')
+                readline.moveCursor(process.stdout, 0, -1)
+
                 readline.clearScreenDown(process.stdout)
             }
-
             rendered = true
-            process.stdout.write('\x1b[s')
 
             process.stdout.write(`${text}(Y/N): ${input}\n`)
+            process.stdout.write('\x1b[s')
+
             if (error) process.stdout.write(`${error}`)
 
             readline.moveCursor(process.stdout, 0, -1)
@@ -171,7 +176,7 @@ export function confirmPrompt(text: string): Promise<boolean> {
             switch (key) {
                 case '\u0003':
                     cleanup()
-                    process.stdout.write('Operation cancelled\n')
+                    process.stdout.write('\nOperation cancelled\n')
                     return process.exit(0)
                 case '\r': {
                     const isValid = !!(input.toLowerCase() === 'y' || input.toLowerCase() === 'n')

--- a/packages/wuchale-add/src/style.ts
+++ b/packages/wuchale-add/src/style.ts
@@ -1,0 +1,23 @@
+export const STYLE = {
+    RESET: '\x1b[0m',
+
+    BOLD: '\x1b[1m',
+    DIM: '\x1b[2m',
+
+    RED: '\x1b[31m',
+    GREEN: '\x1b[32m',
+    BLUE: '\x1b[38;2;128;220;209m',
+    DARK: '\x1b[38;2;24;42;47m',
+}
+
+export function style(text: string, ...styles: string[]) {
+    return `${styles.join('')}${text}${STYLE.RESET}`
+}
+
+export function errorText(text: string) {
+    return `${STYLE.RED}${STYLE.DIM}${text}${STYLE.RESET}`
+}
+
+export function successText(text: string) {
+    return `${STYLE.GREEN}${text}${STYLE.RESET}`
+}

--- a/packages/wuchale-add/src/style.ts
+++ b/packages/wuchale-add/src/style.ts
@@ -8,6 +8,8 @@ export const STYLE = {
     GREEN: '\x1b[32m',
     BLUE: '\x1b[38;2;128;220;209m',
     DARK: '\x1b[38;2;24;42;47m',
+    COMMAND: '\x1b[38;2;255;198;109m',
+    WEBSITE: '\x1b[38;2;198;160;255m',
 }
 
 export function style(text: string, ...styles: string[]) {

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -1,0 +1,9 @@
+export type ProjectKind = 'react' | 'solid-js' | 'svelte' | 'sveltekit' | 'astro' | 'vanilla'
+
+export interface DetectProjectResult {
+    projectKind: ProjectKind
+    detectedPackages: string[]
+    hasViteConfig: boolean
+    hasWuchaleConfig: boolean
+    isTypeScript: boolean
+}

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -29,3 +29,12 @@ export type MultiboxPromptOptions = {
     name: string
     checked: boolean
 }
+
+interface ScaffoldContext {
+    project: DetectProjectResult
+    locales: string[]
+}
+
+export interface ScaffoldModule {
+    scaffold: (ctx: ScaffoldContext) => Promise<void>
+}

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -3,6 +3,7 @@ export type ProjectKind = 'react' | 'solid-js' | 'svelte' | 'sveltekit' | 'astro
 export interface DetectProjectResult {
     projectKind: ProjectKind
     detectedPackages: string[]
+    adapters: string[]
     packageKinds: ProjectKind[]
     hasViteConfig: boolean
     hasWuchaleConfig: boolean
@@ -17,4 +18,9 @@ export interface AdapterConfig {
 export interface PairedAdapterConfig {
     import: { name: string; lib: string }
     content: string
+}
+
+export interface PackageManager {
+    name: string
+    install: string
 }

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -24,3 +24,8 @@ export interface PackageManager {
     name: string
     install: string
 }
+
+export type MultiboxPromptOptions = {
+    name: string
+    checked: boolean
+}

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -3,7 +3,18 @@ export type ProjectKind = 'react' | 'solid-js' | 'svelte' | 'sveltekit' | 'astro
 export interface DetectProjectResult {
     projectKind: ProjectKind
     detectedPackages: string[]
+    packageKinds: ProjectKind[]
     hasViteConfig: boolean
     hasWuchaleConfig: boolean
     isTypeScript: boolean
+}
+
+export interface AdapterConfig {
+    import: { name: string; lib: string }[]
+    content: string[]
+}
+
+export interface PairedAdapterConfig {
+    import: { name: string; lib: string }
+    content: string
 }

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -1,13 +1,18 @@
 export type ProjectKind = 'react' | 'solid-js' | 'svelte' | 'sveltekit' | 'astro' | 'vanilla'
+export type ChoosablePackages = 'react' | 'solid-js' | 'svelte' | 'astro'
 
 export interface DetectProjectResult {
-    projectKind: ProjectKind
-    detectedPackages: string[]
-    adapters: string[]
-    packageKinds: ProjectKind[]
+    packages: ProjectPackage[]
+    packageOverrides: Partial<Record<ProjectKind, ProjectKind>>
     hasViteConfig: boolean
     hasWuchaleConfig: boolean
     isTypeScript: boolean
+}
+
+export type ProjectPackage = {
+    kind: ProjectKind
+    adapter: string
+    choosable: boolean
 }
 
 export interface AdapterConfig {
@@ -27,6 +32,7 @@ export interface PackageManager {
 
 export type MultiboxPromptOptions = {
     name: string
+    adapter: string
     checked: boolean
 }
 
@@ -37,4 +43,12 @@ interface ScaffoldContext {
 
 export interface ScaffoldModule {
     scaffold: (ctx: ScaffoldContext) => Promise<void>
+}
+
+export interface FrameworkDefinition {
+    package: string
+    adapter: string
+    kind: ProjectKind
+    choosable: boolean
+    overrides?: ProjectKind[]
 }

--- a/packages/wuchale-add/src/types.ts
+++ b/packages/wuchale-add/src/types.ts
@@ -6,6 +6,7 @@ export interface DetectProjectResult {
     packageOverrides: Partial<Record<ProjectKind, ProjectKind>>
     hasViteConfig: boolean
     hasWuchaleConfig: boolean
+    hasTailwind: boolean
     isTypeScript: boolean
 }
 

--- a/packages/wuchale-add/src/vite.ts
+++ b/packages/wuchale-add/src/vite.ts
@@ -40,6 +40,7 @@ export function writeViteConfig(project: DetectProjectResult) {
     const s = new MagicString(content)
 
     for (const node of ast.body) {
+        if (analysis.hasImport && analysis.hasPlugin) break
         walkNodes(node)
     }
 
@@ -66,6 +67,7 @@ function getViteConfigExtension(): string | undefined {
 }
 
 function walkNodes(node: Node) {
+    if (analysis.hasImport && analysis.hasPlugin) return
     if (node.type === 'Property') {
         const property = node as Property
 
@@ -82,6 +84,7 @@ function walkNodes(node: Node) {
                     element.callee.name === 'wuchale'
                 ) {
                     analysis.hasPlugin = true
+                    break
                 }
             }
             if (!analysis.hasPlugin) {
@@ -100,6 +103,7 @@ function walkNodes(node: Node) {
                 spec.imported.name === 'wuchale'
             ) {
                 analysis.hasImport = true
+                break
             }
         }
     }

--- a/packages/wuchale-add/src/vite.ts
+++ b/packages/wuchale-add/src/vite.ts
@@ -1,19 +1,35 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { tsPlugin } from '@sveltejs/acorn-typescript'
-import { type Node, Parser, type Program } from 'acorn'
+import type { ImportDeclaration, Node, Property } from 'acorn'
+import { Parser } from 'acorn'
 import MagicString from 'magic-string'
 import type { DetectProjectResult } from './types.js'
 
 const parser = Parser.extend(tsPlugin())
-let hasImport = false
-const hasPlugin = { exist: false, pos: 0 }
+
+type ConfigAnalysis = {
+    hasImport: boolean
+    hasPlugin: boolean
+    pluginPosition: number | null
+}
+
+const analysis: ConfigAnalysis = {
+    hasImport: false,
+    hasPlugin: false,
+    pluginPosition: null,
+}
 
 export function writeViteConfig(project: DetectProjectResult) {
     if (!project.hasViteConfig) {
         return
     }
 
-    const viteFileExtension = checkViteConfigFile()
+    analysis.hasImport = false
+    analysis.hasPlugin = false
+    analysis.pluginPosition = null
+
+    const viteFileExtension = getViteConfigExtension()
+    if (!viteFileExtension) return
 
     const content = readFileSync(`./vite.config.${viteFileExtension}`, 'utf8')
     const ast = parser.parse(content, {
@@ -27,59 +43,80 @@ export function writeViteConfig(project: DetectProjectResult) {
         walkNodes(node)
     }
 
-    if (!hasImport) {
+    if (!analysis.hasImport) {
         s.prepend("import { wuchale } from 'wuchale/vite'\n")
     }
 
-    if (!hasPlugin.exist) {
-        s.appendLeft(hasPlugin.pos, 'wuchale(), ')
+    if (!analysis.hasPlugin && analysis.pluginPosition !== null) {
+        s.appendLeft(analysis.pluginPosition, 'wuchale(), ')
     }
 
     const result = s.toString()
-    writeFileSync(`./vite.config.${viteFileExtension}`, result)
+
+    if (result !== content) {
+        writeFileSync(`./vite.config.${viteFileExtension}`, result)
+    }
 }
 
-function checkViteConfigFile(): string {
+function getViteConfigExtension(): string | undefined {
     if (existsSync('./vite.config.ts')) return 'ts'
-    else return 'js'
+    if (existsSync('./vite.config.js')) return 'js'
+
+    return undefined
 }
 
 function walkNodes(node: Node) {
-    for (const [key, value] of Object.entries(node)) {
-        if (Array.isArray(value)) {
-            for (const child of value) {
-                walkNodes(child)
-            }
-        } else if (typeof value === 'object' && value !== null) {
-            walkNodes(value)
-        }
+    if (node.type === 'Property') {
+        const property = node as Property
 
-        if (node.type === 'Property') {
-            const property = node as any
-            if (property.key.name === 'plugins') {
-                const arr = property.value
-                for (const element of arr.elements) {
-                    if (element.callee.name === 'wuchale') {
-                        hasPlugin.exist = true
-                    }
-                }
-                if (!hasPlugin.exist) {
-                    hasPlugin.pos = arr.start + 1
+        if (
+            property.value.type === 'ArrayExpression' &&
+            property.key.type === 'Identifier' &&
+            property.key.name === 'plugins'
+        ) {
+            const arr = property.value
+            for (const element of arr.elements) {
+                if (
+                    element?.type === 'CallExpression' &&
+                    element.callee.type === 'Identifier' &&
+                    element.callee.name === 'wuchale'
+                ) {
+                    analysis.hasPlugin = true
                 }
             }
-        }
-
-        if (node.type === 'ImportDeclaration') {
-            const importNode = node as any
-            for (const spec of importNode.specifiers) {
-                if (spec.type === 'ImportSpecifier') {
-                    if (spec.imported.type === 'Identifier') {
-                        if (spec.imported.name === 'wuchale') {
-                            hasImport = true
-                        }
-                    }
-                }
+            if (!analysis.hasPlugin) {
+                analysis.pluginPosition = arr.start + 1
             }
         }
     }
+
+    if (node.type === 'ImportDeclaration') {
+        const importNode = node as ImportDeclaration
+        for (const spec of importNode.specifiers) {
+            if (
+                spec.type === 'ImportSpecifier' &&
+                spec.imported.type === 'Identifier' &&
+                importNode.source.value === 'wuchale/vite' &&
+                spec.imported.name === 'wuchale'
+            ) {
+                analysis.hasImport = true
+            }
+        }
+    }
+
+    for (const value of Object.values(node)) {
+        if (Array.isArray(value)) {
+            for (const child of value) {
+                if (isNode(child)) {
+                    walkNodes(child)
+                }
+            }
+        } else if (isNode(value)) {
+            walkNodes(value)
+        }
+    }
+}
+
+function isNode(value: unknown): value is Node {
+    return typeof value === 'object' && value !== null && 'type' in value && typeof value.type === 'string'
 }

--- a/packages/wuchale-add/src/vite.ts
+++ b/packages/wuchale-add/src/vite.ts
@@ -1,0 +1,85 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tsPlugin } from '@sveltejs/acorn-typescript'
+import { type Node, Parser, type Program } from 'acorn'
+import MagicString from 'magic-string'
+import type { DetectProjectResult } from './types.js'
+
+const parser = Parser.extend(tsPlugin())
+let hasImport = false
+const hasPlugin = { exist: false, pos: 0 }
+
+export function writeViteConfig(project: DetectProjectResult) {
+    if (!project.hasViteConfig) {
+        return
+    }
+
+    const viteFileExtension = checkViteConfigFile()
+
+    const content = readFileSync(`./vite.config.${viteFileExtension}`, 'utf8')
+    const ast = parser.parse(content, {
+        sourceType: 'module',
+        ecmaVersion: 'latest',
+    })
+
+    const s = new MagicString(content)
+
+    for (const node of ast.body) {
+        walkNodes(node)
+    }
+
+    if (!hasImport) {
+        s.prepend("import { wuchale } from 'wuchale/vite'\n")
+    }
+
+    if (!hasPlugin.exist) {
+        s.appendLeft(hasPlugin.pos, 'wuchale(), ')
+    }
+
+    const result = s.toString()
+    writeFileSync(`./vite.config.${viteFileExtension}`, result)
+}
+
+function checkViteConfigFile(): string {
+    if (existsSync('./vite.config.ts')) return 'ts'
+    else return 'js'
+}
+
+function walkNodes(node: Node) {
+    for (const [key, value] of Object.entries(node)) {
+        if (Array.isArray(value)) {
+            for (const child of value) {
+                walkNodes(child)
+            }
+        } else if (typeof value === 'object' && value !== null) {
+            walkNodes(value)
+        }
+
+        if (node.type === 'Property') {
+            const property = node as any
+            if (property.key.name === 'plugins') {
+                const arr = property.value
+                for (const element of arr.elements) {
+                    if (element.callee.name === 'wuchale') {
+                        hasPlugin.exist = true
+                    }
+                }
+                if (!hasPlugin.exist) {
+                    hasPlugin.pos = arr.start + 1
+                }
+            }
+        }
+
+        if (node.type === 'ImportDeclaration') {
+            const importNode = node as any
+            for (const spec of importNode.specifiers) {
+                if (spec.type === 'ImportSpecifier') {
+                    if (spec.imported.type === 'Identifier') {
+                        if (spec.imported.name === 'wuchale') {
+                            hasImport = true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/wuchale-add/tsconfig.build.json
+++ b/packages/wuchale-add/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig.dev.json",
+    "compilerOptions": {
+        "rootDir": "src"
+    },
+    "include": ["src"],
+    "exclude": ["**/*.test.ts"]
+}

--- a/packages/wuchale-add/tsconfig.dev.json
+++ b/packages/wuchale-add/tsconfig.dev.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig-base",
+    "compilerOptions": {
+        "outDir": "dist",
+        "composite": true
+    },
+    "references": [{ "path": "./tsconfig.build.json" }],
+    "include": ["src", "testing"]
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -7,6 +7,7 @@
         { "path": "./packages/svelte/tsconfig.build.json" },
         { "path": "./packages/jsx/tsconfig.build.json" },
         { "path": "./packages/astro/tsconfig.build.json" },
-        { "path": "./packages/json/tsconfig.build.json" }
+        { "path": "./packages/json/tsconfig.build.json" },
+        { "path": "./packages/wuchale-add/tsconfig.build.json" }
     ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         { "path": "./packages/svelte/tsconfig.dev.json" },
         { "path": "./packages/jsx/tsconfig.dev.json" },
         { "path": "./packages/astro/tsconfig.dev.json" },
-        { "path": "./packages/json/tsconfig.dev.json" }
+        { "path": "./packages/json/tsconfig.dev.json" },
+        { "path": "./packages/wuchale-add/tsconfig.dev.json" }
     ]
 }


### PR DESCRIPTION
This PR implements `wuchale-add` scaffold CLI for wuchale.

## What it does for now:
- Detects installed frameworks from `package.json` file
- Asks what languages the app should support
- Asks which adapters should be installed
- Installs selected adapters + `wuchale` package via detected package manager
- Generates `wuchale.config.js` config if it doesn't exist
- Injects `wuchale()` into existing Vite config
- Appends `.wuchale` directory to .gitignore file
- Runs scaffold from adapters

## Known current issues:
- `wuchale()` injection in Vite config doesn't work if plugins are created as separate variable
- During prompts, if the user types a long input that wraps to the next line, the CLI will print duplicate question lines

## What's not included yet
- `@wuchale/jsx` scaffold module
- `@wuchale/astro` scaffold module

If you have any suggestions for changes or any problems you encounter please let me know.